### PR TITLE
Add argument to specify the character length for message splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ Meshtastic-SAME-EAS-Alerter --test-channel <CHANNEL_NUMBER_HERE>
 Meshtastic-SAME-EAS-Alerter --rate <SAMPLING_RATE_HERE>
 ```
 
+### msg chars
+- Specify the number of characters to split each message into.
+- Must be between 75 and 200
+- Default is  75
+
 ### locations
 - Input the location codes of counties you want to filter for
 - If a alert does not contain the counties you are filtering for it will be ignored

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Meshtastic-SAME-EAS-Alerter --rate <SAMPLING_RATE_HERE>
 - Must be between 75 and 200
 - Default is  75
 
+```
+Meshtastic-SAME-EAS-Alerter --msg-chars 150
+```
+
 ### locations
 - Input the location codes of counties you want to filter for
 - If a alert does not contain the counties you are filtering for it will be ignored

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Meshtastic-SAME-EAS-Alerter --rate <SAMPLING_RATE_HERE>
 ```
 
 ### msg chars
-- Specify the number of characters to split each message into.
+- Specify the number of characters to split the alerts into. 
+- Alerts are sent as multiple messages each `msg_chars` length or less.
 - Must be between 75 and 200
 - Default is  75
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,10 @@ struct Args {
     #[arg(long, short)]
     test_channel: Option<u32>,
 
+    /// Number of characters to split messages into
+    #[arg(long, short)]
+    msg_chars: Option<usize>,
+
     /// Network address with port of device to connect to in the form of target.address:port
     #[arg(long)]
     host: Option<String>,
@@ -234,6 +238,9 @@ async fn main() -> Result<()> {
     // 10 means that tests will not be logged
     let mut test_channel: u32 = 10;
 
+    // Default value of message_chars
+    let mut msg_chars: usize = 75;
+
     // Parse the command line arguments
     let args = Args::parse();
 
@@ -255,6 +262,15 @@ async fn main() -> Result<()> {
             return Err(anyhow::anyhow!("testChannel must be between 0 and 7"));
         } else {
             test_channel = test_channel_arg;
+        }
+    }
+
+    if let Some(msg_chars_arg) = args.msg_chars {
+        if msg_chars_arg < 75 || msg_chars_arg > 200 {
+            return Err(anyhow::anyhow!("Message characters must be between 75 and 200"));
+        }
+        else {
+            msg_chars = msg_chars_arg
         }
     }
 
@@ -313,7 +329,7 @@ async fn main() -> Result<()> {
                             log::info!("Ignoring test alert");
                             continue;
                         }
-                        message = "📖Received ".to_string()
+                        message = "".to_string()
                             + &evt.to_string()
                             + " from "
                             + hdr.callsign()
@@ -405,13 +421,13 @@ async fn main() -> Result<()> {
 
                 log::info!("Attempting to send message over the mesh: {}", message);
 
-                // Split and send the message in chunks of 75 characters, using retry logic
+                // Split and send the message in chunks of msg_chars characters, using retry logic
                 let mut myvec: Vec<usize> = message.bytes().enumerate().filter(|(_,c)| *c == b' ').map(|(i,_)| i).collect::<Vec<_>>();
                 let mut curpos: usize = 0;
                 let mut curlen: usize = 0;
                 let mut startpos: usize = 0;
                 for i in myvec.iter_mut() {
-                    if curlen + *i - curpos > 75 {
+                    if curlen + *i - curpos > msg_chars {
                         sender
                             .send_message_with_retry(send_channel, &message[startpos..(startpos + curlen)], 3, Duration::from_secs(5), Args::parse())
                             .await.expect("Failed sending msg");

--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,7 @@ async fn main() -> Result<()> {
                             log::info!("Ignoring test alert");
                             continue;
                         }
-                        message = "".to_string()
+                        message = "📖Received ".to_string()
                             + &evt.to_string()
                             + " from "
                             + hdr.callsign()


### PR DESCRIPTION
This PR adds an argument, `msg_chars` allowing you to specify the message split size at runtime.  Useful if you want to send fewer, longer messages since the default of 75 takes longer to send multiple messages that could be sent in a single message.  The maximum message size for Meshtastic is 200 characters.

The default is still  75 characters if not specified, and there are checks to ensure the value specified is between 75 and 200.
