### PR TITLE
Phase 2.2: rebrand project documentation to Sentinel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "strum",
  "thiserror 1.0.69",
  "tokio",
+ "ureq",
 ]
 
 [[package]]
@@ -183,6 +184,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -396,6 +403,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +446,15 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -618,6 +645,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +821,12 @@ name = "linux-raw-sys"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -951,6 +1087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,6 +1155,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1161,9 +1312,9 @@ checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1249,6 +1400,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1477,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1517,6 +1717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1776,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1653,6 +1876,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1961,45 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1822,6 +2094,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2094,6 +2384,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2426,66 @@ name = "zerocopy-derive"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ rust-embed = "8.4.0"
 serde = { version = "1.0.203", features = ["derive"] }
 csv = "1.3.0"
 simple_logger = "5.0.0"
+ureq = { version = "2.12.1", default-features = false, features = ["tls"] }

--- a/README.md
+++ b/README.md
@@ -1,200 +1,176 @@
-# Sentinel
+# Project Sentinel
 
-**Offline-first emergency alerting and disaster communications platform**
+Project Sentinel is an offline-first NOAA SAME/EAS alert relay for resilient emergency communications. It decodes NOAA Weather Radio SAME alerts from an SDR audio stream, applies local routing and county filtering rules, and sends alert text to a Meshtastic mesh as the required primary delivery path.
 
-Sentinel is an open-source emergency communications platform designed to operate during natural disasters, industrial incidents, and prolonged infrastructure outages.
+Sentinel extends the upstream [RCGV1/Meshtastic-SAME-EAS-Alerter](https://github.com/RCGV1/Meshtastic-SAME-EAS-Alerter) project. The upstream project provided the foundation for SAME decoding, county filtering, alert formatting, and Meshtastic CLI delivery. Sentinel preserves that behavior while adding a synchronous sender/fan-out architecture, an optional Discord webhook sender, and an optional best-effort failure spool.
 
-The project began as a fork of Meshtastic-SAME-EAS-Alerter and has evolved into a broader effort to provide resilient, multi-network alert dissemination and situational awareness capabilities.
+## Mission
 
-Sentinel prioritizes:
-
-* Offline operation
-* Graceful degradation under failure
-* Modular architecture
-* Open-source development
-* Interoperability between communication systems
-* Support for both community and industrial emergency response
-
----
+Sentinel exists to keep critical alerts moving when normal infrastructure is degraded, overloaded, or unavailable. The current project focuses on local NOAA SAME decoding and mesh-first alert delivery, with optional integrations that must never weaken the primary offline-capable path.
 
 ## Current Capabilities
 
-### NOAA SAME Alert Monitoring
+* NOAA SAME/EAS decoding from stdin audio samples.
+* SAME county/location filtering with national alert override.
+* Test alert routing with optional `--test-channel`.
+* Required Meshtastic delivery through the Meshtastic Python CLI.
+* Optional Discord webhook delivery.
+* Optional best-effort failure spool for optional sender failures.
+* Synchronous sender/fan-out architecture.
 
-Sentinel receives NOAA Weather Radio broadcasts using an RTL-SDR and decodes SAME (Specific Area Message Encoding) alerts locally.
+Sentinel does not currently include Reticulum/LXMF, MeshCore, replay workers, dashboard, Skywarn ingestion, ATAK interoperability, CAP ingestion, or background processing.
 
-No internet connection is required.
+## Architecture Overview
 
-Supported alert types include:
-
-* Warnings
-* Watches
-* Statements
-* Civil emergency messages
-* National activations
-* Weekly/monthly test alerts
-
----
-
-### Meshtastic Integration (Required Sender)
-
-Sentinel forwards qualifying alerts to Meshtastic networks using the Meshtastic Python CLI.
-
-Features:
-
-* Serial node support
-* TCP node support
-* Configurable alert channel
-* Optional test alert channel
-* County/location filtering
-* National alert overrides
-
-Meshtastic remains Sentinel's primary delivery mechanism.
-
----
-
-### Discord Integration (Optional Sender)
-
-Sentinel can optionally forward alerts to Discord using webhook URLs.
-
-Features:
-
-* Optional configuration
-* Best-effort delivery
-* Does not interfere with Meshtastic operation
-* Discord failures do not prevent radio delivery
-
----
-
-### Failure Spooling (Optional)
-
-Sentinel can optionally record failed best-effort sender deliveries to a local spool file.
-
-Features:
-
-* Disabled by default
-* File-backed durability
-* No background worker required
-* Does not impact Meshtastic delivery
-
----
-
-## Architecture
-
-Sentinel follows an offline-first fan-out architecture.
-
-```text
-RTL-SDR
-    ↓
-NOAA SAME Decoder
-    ↓
-Filtering Engine
-    ↓
-Alert Model
-    ↓
-Fan-Out Engine
-     ├─ Meshtastic (required)
-     ├─ Discord (optional)
-     └─ Failure Spool (optional)
+```mermaid
+flowchart TD
+    A["RTL-SDR / NOAA Weather Radio audio"] --> B["rtl_fm"]
+    B --> C["Sentinel stdin audio input"]
+    C --> D["SAME decoder"]
+    D --> E["Alert channel and test routing"]
+    E --> F["County filter / national override"]
+    F --> G["Alert model and formatted message"]
+    G --> H["FanOut"]
+    H --> I["Required sender: Meshtastic"]
+    H --> J["Best-effort sender: Discord, if configured"]
+    J --> K["Optional failure spool, if configured"]
 ```
 
-Future integrations will extend this architecture without replacing it.
+Sentinel separates senders into two groups:
 
----
+* Required senders must succeed. Meshtastic is currently the only required sender.
+* Best-effort senders are optional. Discord is currently the only best-effort sender and is registered only when `--discord-webhook-url` is provided.
+
+The optional failure spool is enabled only with `--spool-path <PATH>`. It records failed best-effort sender attempts only. It is not a general alert journal and it does not currently replay failures.
+
+For more detail, see:
+
+* [Architecture](docs/ARCHITECTURE.md)
+* [Roadmap](docs/ROADMAP.md)
 
 ## Installation
 
-Installation instructions are currently focused on Raspberry Pi deployments using RTL-SDR and Meshtastic.
+Sentinel currently depends on the same operational inputs as the upstream alerter:
 
-Detailed setup documentation will continue to evolve as Sentinel expands.
+1. Install `rtl_fm`.
+   * On Raspberry Pi OS / Raspbian, the upstream guide references these instructions: <https://fuzzthepiguy.tech/rtl_fm-install/>
+2. Install the Meshtastic Python CLI.
+   * Meshtastic CLI installation: <https://meshtastic.org/docs/software/python/cli/installation/>
+3. Build or install Sentinel.
 
----
+From source:
+
+```sh
+cargo build --release
+```
+
+The executable name is inherited from the upstream package:
+
+```sh
+target/release/Meshtastic-SAME-EAS-Alerter --help
+```
+
+Release package names may still use the inherited upstream binary/package naming while Sentinel evolves.
 
 ## Usage
 
-### NOAA Monitoring Example
+Sentinel expects audio from `rtl_fm` on stdin. Tune `rtl_fm` to the nearest NOAA Weather Radio station, typically in the 162.400 MHz to 162.550 MHz range.
 
-```bash
-rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel
+```sh
+rtl_fm -f <FREQUENCY_IN_HZ> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter
 ```
 
-### Discord Integration
+The frequency is provided to `rtl_fm` in Hz, not MHz.
 
-```bash
-rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel \
-  --discord-webhook-url <WEBHOOK_URL>
+### Meshtastic
+
+By default, the Meshtastic CLI attempts to find a connected node via serial or localhost. You can also provide a TCP host or serial port.
+
+```sh
+Meshtastic-SAME-EAS-Alerter --host <TCP_HOST:PORT>
+Meshtastic-SAME-EAS-Alerter --port <SERIAL_PORT>
 ```
 
-### Failure Spool
+Alert channel:
 
-```bash
-rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel \
-  --spool-path ./sentinel-spool.log
+```sh
+Meshtastic-SAME-EAS-Alerter --alert-channel <CHANNEL_NUMBER>
 ```
 
----
+If omitted, alert messages default to channel `0`.
 
-## Current CLI Options
+Test channel:
 
-* `--alert-channel`
-* `--test-channel`
-* `--host`
-* `--port`
-* `--rate`
-* `--locations`
-* `--discord-webhook-url`
-* `--spool-path`
-
-Run:
-
-```bash
-sentinel --help
+```sh
+Meshtastic-SAME-EAS-Alerter --test-channel <CHANNEL_NUMBER>
 ```
 
-for the latest options.
+If omitted, test alerts are ignored.
 
----
+### Sample Rate
 
-## Roadmap
+The default sample rate is `48000`.
 
-The Sentinel roadmap is maintained in:
-
-```text
-docs/ROADMAP.md
+```sh
+Meshtastic-SAME-EAS-Alerter --rate <SAMPLE_RATE>
 ```
 
-Planned capabilities include:
+Do not change this unless your audio pipeline requires it.
 
-* Reticulum / LXMF integration
-* MeshCore integration
-* Retry and replay workers
-* Incident Command dashboard
-* Skywarn ingestion
-* ATAK interoperability
+### Location Filtering
 
----
+Use `--locations` to send only alerts containing specific SAME location codes.
 
-## Legal
+```sh
+Meshtastic-SAME-EAS-Alerter --locations 006085,006087
+```
 
-Sentinel is an independent open-source project.
+If no locations are provided, non-national alerts are allowed. National alerts bypass the location filter. Location codes are listed in [src/sameCodes.csv](src/sameCodes.csv).
 
-This project is not endorsed by or affiliated with:
+### Optional Discord Webhook
 
-* Meshtastic LLC
-* The National Weather Service
-* FEMA
-* NOAA
+Discord delivery is disabled by default. It is enabled only when a webhook URL is provided.
 
-Meshtastic® is a registered trademark of Meshtastic LLC.
+```sh
+Meshtastic-SAME-EAS-Alerter --discord-webhook-url <DISCORD_WEBHOOK_URL>
+```
 
-Use at your own risk.
+Discord is best-effort. Discord failures are logged and do not block Meshtastic delivery. Sentinel does not log the full webhook URL.
 
----
+### Optional Best-Effort Failure Spool
 
-## Acknowledgements
+The failure spool is disabled by default. It is enabled only when a path is provided.
 
-Sentinel originated as a fork of:
+```sh
+Meshtastic-SAME-EAS-Alerter --spool-path <PATH>
+```
 
-RCGV1/Meshtastic-SAME-EAS-Alerter
+When enabled, Sentinel appends one-line JSONL-style records for failed best-effort sender attempts. Required Meshtastic failures are not spooled. Spool write failures do not block fan-out completion.
 
-We are grateful to the original authors and contributors whose work made Sentinel possible.
+### Full Examples
+
+Meshtastic only:
+
+```sh
+rtl_fm -f <FREQUENCY_IN_HZ> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter --alert-channel 0 --test-channel 1
+```
+
+Meshtastic over TCP:
+
+```sh
+rtl_fm -f <FREQUENCY_IN_HZ> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter --host <TCP_HOST:PORT> --alert-channel 0
+```
+
+Meshtastic with optional Discord and best-effort failure spool:
+
+```sh
+rtl_fm -f <FREQUENCY_IN_HZ> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter --alert-channel 0 --discord-webhook-url <DISCORD_WEBHOOK_URL> --spool-path sentinel-failures.jsonl
+```
+
+## Legal Disclaimer
+
+Sentinel is not an official emergency alerting system and is not a substitute for NOAA Weather Radio, Wireless Emergency Alerts, Emergency Alert System broadcasts, local emergency management instructions, or other official warning channels.
+
+Use Sentinel at your own risk. Operators are responsible for validating their hardware, radio coverage, alert routing, message delivery, and compliance with applicable laws, regulations, and organizational policies.
+
+This project is neither endorsed by nor supported by Meshtastic. Meshtastic is a registered trademark of Meshtastic LLC. NOAA, NWS, FEMA, EAS, Discord, and other names may be trademarks or service marks of their respective owners.

--- a/README.md
+++ b/README.md
@@ -1,134 +1,200 @@
-# Meshtastic SAME EAS Alerter
+# Sentinel
 
+**Offline-first emergency alerting and disaster communications platform**
 
-<a href="https://www.weather.gov/" class="image-container">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/ff/US-NationalWeatherService-Logo.svg/2048px-US-NationalWeatherService-Logo.svg.png" width=100>
-</a>
+Sentinel is an open-source emergency communications platform designed to operate during natural disasters, industrial incidents, and prolonged infrastructure outages.
 
-<a href="https://www.fema.gov/emergency-managers/practitioners/integrated-public-alert-warning-system/public/emergency-alert-system" class="image-container">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/1/15/EAS_new.svg" width=120>
-</a>
+The project began as a fork of Meshtastic-SAME-EAS-Alerter and has evolved into a broader effort to provide resilient, multi-network alert dissemination and situational awareness capabilities.
 
-<a href="https://Meshtastic.org" class="image-container">
-    <img src="https://github.com/meshtastic/design/blob/master/Meshtastic%20Powered%20Logo/M-POWERED.png?raw=true" width=100>
-</a>
+Sentinel prioritizes:
 
-The Meshtastic SAME EAS Alerter is a lightweight tool designed to forward warnings, emergencies, or statements sent over the air to a local Meshtastic network. It operates without needing a WiFi connection. The setup involves connecting the hosting computer to an RTL SDR via USB and to a running Meshtastic node via serial or TCP.
+* Offline operation
+* Graceful degradation under failure
+* Modular architecture
+* Open-source development
+* Interoperability between communication systems
+* Support for both community and industrial emergency response
 
-![Flood Example](./images/Flood.jpg)
+---
+
+## Current Capabilities
+
+### NOAA SAME Alert Monitoring
+
+Sentinel receives NOAA Weather Radio broadcasts using an RTL-SDR and decodes SAME (Specific Area Message Encoding) alerts locally.
+
+No internet connection is required.
+
+Supported alert types include:
+
+* Warnings
+* Watches
+* Statements
+* Civil emergency messages
+* National activations
+* Weekly/monthly test alerts
+
+---
+
+### Meshtastic Integration (Required Sender)
+
+Sentinel forwards qualifying alerts to Meshtastic networks using the Meshtastic Python CLI.
+
+Features:
+
+* Serial node support
+* TCP node support
+* Configurable alert channel
+* Optional test alert channel
+* County/location filtering
+* National alert overrides
+
+Meshtastic remains Sentinel's primary delivery mechanism.
+
+---
+
+### Discord Integration (Optional Sender)
+
+Sentinel can optionally forward alerts to Discord using webhook URLs.
+
+Features:
+
+* Optional configuration
+* Best-effort delivery
+* Does not interfere with Meshtastic operation
+* Discord failures do not prevent radio delivery
+
+---
+
+### Failure Spooling (Optional)
+
+Sentinel can optionally record failed best-effort sender deliveries to a local spool file.
+
+Features:
+
+* Disabled by default
+* File-backed durability
+* No background worker required
+* Does not impact Meshtastic delivery
+
+---
+
+## Architecture
+
+Sentinel follows an offline-first fan-out architecture.
+
+```text
+RTL-SDR
+    ↓
+NOAA SAME Decoder
+    ↓
+Filtering Engine
+    ↓
+Alert Model
+    ↓
+Fan-Out Engine
+     ├─ Meshtastic (required)
+     ├─ Discord (optional)
+     └─ Failure Spool (optional)
+```
+
+Future integrations will extend this architecture without replacing it.
+
+---
+
+## Installation
+
+Installation instructions are currently focused on Raspberry Pi deployments using RTL-SDR and Meshtastic.
+
+Detailed setup documentation will continue to evolve as Sentinel expands.
+
+---
+
+## Usage
+
+### NOAA Monitoring Example
+
+```bash
+rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel
+```
+
+### Discord Integration
+
+```bash
+rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel \
+  --discord-webhook-url <WEBHOOK_URL>
+```
+
+### Failure Spool
+
+```bash
+rtl_fm -f <FREQUENCY_HZ> -s 48000 -r 48000 | sentinel \
+  --spool-path ./sentinel-spool.log
+```
+
+---
+
+## Current CLI Options
+
+* `--alert-channel`
+* `--test-channel`
+* `--host`
+* `--port`
+* `--rate`
+* `--locations`
+* `--discord-webhook-url`
+* `--spool-path`
+
+Run:
+
+```bash
+sentinel --help
+```
+
+for the latest options.
+
+---
+
+## Roadmap
+
+The Sentinel roadmap is maintained in:
+
+```text
+docs/ROADMAP.md
+```
+
+Planned capabilities include:
+
+* Reticulum / LXMF integration
+* MeshCore integration
+* Retry and replay workers
+* Incident Command dashboard
+* Skywarn ingestion
+* ATAK interoperability
+
+---
 
 ## Legal
-This project is neither endorsed by nor supported by Meshtastic.
 
-Meshtastic® is a registered trademark of Meshtastic LLC. Meshtastic software components are released under various licenses, see GitHub for details. No warranty is provided - use at your own risk.
+Sentinel is an independent open-source project.
 
+This project is not endorsed by or affiliated with:
 
-## 💿 Installation
-# ATTENTION: For the newest version you must install the python CLI  
-Installation example for Raspbian
-1. Install rtl_fm.  
-   follow these [instructions](https://fuzzthepiguy.tech/rtl_fm-install/)
-2. Install the Meshtastic Python CLI  
-   Follow these [instructions](https://meshtastic.org/docs/software/python/cli/installation/)
-3. Install Meshtastic-SAME-EAS-Alerter
-````
-# Download the updated .deb file
-wget https://github.com/RCGV1/Meshtastic-SAME-EAS-Alerter/releases/download/v<VERSION_NUMBER_HERE>/Meshtastic-SAME-EAS-Alerter_<VERSION_NUMBER_HERE>_arm64.deb
+* Meshtastic LLC
+* The National Weather Service
+* FEMA
+* NOAA
 
-# Install the .deb package
-sudo dpkg -i Meshtastic-SAME-EAS-Alerter_<VERSION_NUMBER_HERE>_arm64.deb
+Meshtastic® is a registered trademark of Meshtastic LLC.
 
-# Fix any dependency issues
-sudo apt-get install -f
-````
+Use at your own risk.
 
-Other operating systems may have a different installation
+---
 
+## Acknowledgements
 
+Sentinel originated as a fork of:
 
-## 🖋️ Usage
-### By default the alerter will find a connected node that is connected via serial or on local host
+RCGV1/Meshtastic-SAME-EAS-Alerter
 
-### RTL FM input
-- You must pass in the input from an rtl fm stream
-- For a detailed installation guide of rtl_fm check out the Installation instructions
-- Set the desired frequency to the nearest National Weather Service radio station typically in the 162.40 to 162.55 MHz range
-```
-rtl_fm -f <FREQUENCY_IN_HZ_HERE> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter
-```
-> The frequency input is in Hz not MHz
-
-### help
-```
-Meshtastic-SAME-EAS-Alerter --help
-```
-
-### host
-- Enter the address of the TCP host to connect to, in the form of IP:PORT
-```
-Meshtastic-SAME-EAS-Alerter --host <TCP_HOST_HERE>
-```
-
-### alert channel  
-- Input the channel number that alerts will be sent to  
-- By default, (if nothing is provided) alerts will be sent to channel number 0  
-```
-Meshtastic-SAME-EAS-Alerter --alert-channel <CHANNEL_NUMBER_HERE>
-```
-
-### test channel  
-- Input the channel number that test messages will be sent to  
-  - Usually test messages are transmitted weekly from the weather service station  
-  - These messages can help you tell if your system is working but they can be annoying as they happen often  
-- By default, (if nothing is provided) test messages will be ignored  
-```
-Meshtastic-SAME-EAS-Alerter --test-channel <CHANNEL_NUMBER_HERE>
-```
-
-### sample rate
-- Input the sampling rate of the input
-- Do not modify this if you do not know what you are doing
-- Default is 48000
-```
-Meshtastic-SAME-EAS-Alerter --rate <SAMPLING_RATE_HERE>
-```
-
-### locations
-- Input the location codes of counties you want to filter for
-- If a alert does not contain the counties you are filtering for it will be ignored
-- By default if this arg is not provided all alerts will be sent of all locations (Most likley your local NWS will only alert of nearby alerts)
-- National alerts override this
-- Look in [sameCodes](src/sameCodes.csv) to find the county codes to use
-```
-Meshtastic-SAME-EAS-Alerter --locations <LOCATIONS_HERE>
-```
-example:    
-```
-Meshtastic-SAME-EAS-Alerter --locations 006085,006087
-```
-
-
-### Full example
-- You need both a Meshtastic serial port passed as an arg and rtl fm to run this
-- Alert channel and test channel are optional (see above)
-- By default (if host is not provided) the alerter will find a node that is connected via serial or on local host
-````
-rtl_fm -f <FREQUENCY_IN_HZ_HERE> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter --alert-channel <CHANNEL_NUMBER_HERE> --test-channel <CHANNEL_NUMBER_HERE>
-````
-or
-````
-rtl_fm -f <FREQUENCY_IN_HZ_HERE> -s 48000 -r 48000 | Meshtastic-SAME-EAS-Alerter --host <TCP_HOST_HERE> --alert-channel <CHANNEL_NUMBER_HERE> --test-channel <CHANNEL_NUMBER_HERE>
-````
-> Remember to replace the placeholder values
-
-# 📓 TODO
-PRs are welcome
-- [ ] Canadian Location Codes and marine
-- [x] Connect to a node over TCP
-- [ ] Live audio to text transcription for forwarding instructions sent after the SAME header
-
-# 📇 Contact
-If you need assistance deploying an alerter feel free to contact me
-- Discord: RCGV_
-- Email: Benjaminfaer@gmail.com
-
+We are grateful to the original authors and contributors whose work made Sentinel possible.

--- a/SENTINEL_GOAL.md
+++ b/SENTINEL_GOAL.md
@@ -1,0 +1,247 @@
+# Project Sentinel: Unified Disaster Communications and Alert Platform
+
+## Mission
+
+Build a resilient, portable, offline-capable emergency communications and situational awareness platform designed for deployment during natural disasters, industrial incidents, and prolonged infrastructure outages.
+
+The system must function as a self-contained Incident Command communications hub capable of operating with or without internet connectivity.
+
+The platform should prioritize life safety, interoperability, modularity, and reliability over feature complexity.
+
+---
+
+## Primary Objectives
+
+1. Provide automated alert dissemination from NOAA, SAME, NWS CAP feeds, and other emergency sources.
+2. Operate during extended power and communications outages.
+3. Bridge multiple independent communications networks into a unified alert ecosystem.
+4. Provide a common operational picture for field personnel and incident command.
+5. Be deployable in a Pelican case by a single individual within 15 minutes.
+6. Support both community emergency response and industrial emergency management scenarios.
+
+---
+
+## Supported Communications Networks
+
+### Meshtastic
+
+* Primary low-bandwidth LoRa alerting network.
+* Support:
+
+  * Direct messages
+  * Channel broadcasts
+  * Multi-channel operation
+  * MQTT bridging when internet is available.
+* Maintain compatibility with upstream Meshtastic releases.
+
+---
+
+### Reticulum / LXMF
+
+* Encrypted, decentralized messaging backbone.
+* Support:
+
+  * LXMF message delivery
+  * Propagation nodes
+  * Store-and-forward capability
+  * Hybrid transport over Wi-Fi, Ethernet, and LoRa.
+* Allow independent operation if Meshtastic is unavailable.
+
+---
+
+### MeshCore
+
+* Local off-grid community messaging layer.
+* Support:
+
+  * Room broadcasts
+  * Contact messaging
+  * Gateway operation
+  * CLI and API integration.
+
+---
+
+### Skywarn Integration
+
+* Monitor designated amateur radio frequencies.
+* Detect and process severe weather reports.
+* Long-term objective:
+
+  * AI-assisted voice transcription.
+  * Extraction of actionable weather intelligence.
+  * Conversion into structured alert objects.
+
+---
+
+### NOAA / SAME / CAP
+
+* Support multiple alert acquisition methods:
+
+  * RTL-SDR SAME decoding.
+  * NOAA Weather Radio monitoring.
+  * National Weather Service CAP API ingestion.
+* SAME decoding shall remain the preferred offline alert source.
+* Internet-based CAP shall supplement but never replace local SAME capability.
+
+---
+
+## Incident Command Dashboard
+
+Develop a unified dashboard displaying:
+
+### Network Status
+
+* Meshtastic health.
+* Reticulum health.
+* MeshCore health.
+* SDR health.
+* Internet availability.
+* Power status.
+
+### Active Alerts
+
+* Tornado warnings.
+* Flash flood warnings.
+* Civil emergency messages.
+* Hazardous materials alerts.
+* Industrial emergency notifications.
+
+### Resource Tracking
+
+* Node inventory.
+* Field team status.
+* GPS-enabled assets.
+* Communication path visualization.
+
+---
+
+## Alert Fan-Out Engine
+
+Create a common alert object.
+
+All inbound alerts shall be normalized into this format before distribution.
+
+Potential destinations include:
+
+* Meshtastic
+* Reticulum LXMF
+* MeshCore
+* Discord
+* Email
+* SMS gateways
+* ATAK
+* Incident Command dashboard
+* Future integrations.
+
+Filtering rules shall support:
+
+* SAME county codes.
+* Event type.
+* Severity.
+* Originator.
+* National-level overrides.
+* User-defined distribution groups.
+
+---
+
+## Offline-First Philosophy
+
+The system shall assume internet connectivity is unavailable.
+
+Core functionality must continue operating without:
+
+* Cloud services.
+* External APIs.
+* Cellular connectivity.
+* Commercial power.
+
+Internet connectivity, when available, enhances capability but is never required for mission-critical operations.
+
+---
+
+## Hardware Objectives
+
+Primary deployment platform:
+
+* Raspberry Pi 4B or newer.
+
+Secondary deployment options:
+
+* LattePanda.
+* Standard Linux systems.
+* Containerized environments.
+
+Field deployment hardware:
+
+* Pelican case enclosure.
+* LiFePO4 battery system.
+* Solar charging capability.
+* Meshtastic gateway node.
+* Reticulum gateway node.
+* MeshCore gateway node.
+* RTL-SDR receivers.
+* External antenna connections.
+
+---
+
+## Software Design Principles
+
+1. Modular architecture.
+2. Plugin-based integrations.
+3. Open-source licensing.
+4. Extensive automated testing.
+5. Configuration-driven behavior.
+6. Graceful degradation under failure conditions.
+7. Minimal hardware requirements.
+8. Comprehensive logging and observability.
+
+---
+
+## Development Priorities
+
+### Phase 1
+
+* NOAA SAME decoding.
+* Meshtastic alert forwarding.
+* County filtering.
+* Test alert handling.
+
+### Phase 2
+
+* Discord integration.
+* Reticulum LXMF integration.
+* MeshCore integration.
+* Alert spooling and retry mechanisms.
+
+### Phase 3
+
+* Unified Incident Command dashboard.
+* Alert history and analytics.
+* GPS asset visualization.
+* Role-based user interfaces.
+
+### Phase 4
+
+* AI-assisted Skywarn transcription.
+* Automatic severe weather intelligence extraction.
+* ATAK interoperability.
+* Predictive incident support tools.
+
+### Phase 5
+
+* Multi-case deployment support.
+* High-availability clustering.
+* Community mesh federation.
+* Industrial incident command enhancements.
+
+---
+
+## Success Criteria
+
+The project is successful when:
+
+* A Tornado Warning received via NOAA SAME can automatically propagate through Meshtastic, Reticulum, MeshCore, and Incident Command interfaces within seconds.
+* The system remains functional during a multi-day power outage.
+* Field personnel receive actionable alerts regardless of which supported communications network they use.
+* The platform can be deployed rapidly by a single operator.
+* The solution remains maintainable and extensible for future emergency communications technologies.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,171 @@
+# Sentinel Architecture
+
+## Mission
+
+Sentinel turns NOAA SAME/EAS alerts into resilient, operator-focused messages for off-grid and degraded-infrastructure communications. The current system preserves the upstream Meshtastic alerting behavior while extending it into a modular sender architecture.
+
+## Offline-First Philosophy
+
+Sentinel is designed around the assumption that normal infrastructure may be unreliable or unavailable during emergencies. Local decoding, local filtering, and local mesh delivery remain the core path. Network-dependent integrations are optional and must not weaken the primary offline-capable alert path.
+
+Guiding principles:
+
+* Keep local alert handling usable without cloud services.
+* Preserve deterministic alert routing and filtering.
+* Treat optional integrations as extensions, not dependencies.
+* Prefer synchronous, inspectable behavior until a clear need exists for more complexity.
+* Keep failures visible without allowing optional failures to block required delivery.
+
+## Current Alert Flow
+
+Sentinel currently reads SDR audio samples from stdin, decodes SAME/EAS messages, filters alerts, formats a message, and sends it through the configured fan-out.
+
+```mermaid
+flowchart TD
+    A["RTL-SDR / audio pipeline"] --> B["stdin i16 audio samples"]
+    B --> C["sameold SAME receiver"]
+    C --> D{"StartOfMessage?"}
+    D -->|yes| E["Extract event, originator, callsign, locations"]
+    E --> F["Determine alert/test channel"]
+    F --> G{"Test alert ignored?"}
+    G -->|yes| H["Skip alert"]
+    G -->|no| I{"National alert?"}
+    I -->|yes| L["Bypass county filter"]
+    I -->|no| J{"Location filter configured?"}
+    J -->|yes| K{"Any matching SAME code?"}
+    K -->|no| H
+    K -->|yes| M["Resolve location names"]
+    J -->|no| M
+    L --> N["Format Alert"]
+    M --> N
+    N --> O["FanOut send_alert"]
+```
+
+## SAME Decoding Flow
+
+The decoding path remains the upstream-derived behavior:
+
+* Audio is read from stdin as native-endian `i16` samples.
+* Samples are converted to `f32`.
+* `sameold::SameReceiverBuilder` performs SAME decoding.
+* `Message::StartOfMessage` drives alert processing.
+* `Message::EndOfMessage` is logged.
+
+This phase does not add CAP ingestion, internet polling, Skywarn ingestion, or other alert sources.
+
+## Alert Filtering Flow
+
+Filtering is intentionally conservative and unchanged in spirit from the upstream project:
+
+* Test alerts use `--test-channel` when provided.
+* Test alerts are ignored when no test channel is configured.
+* Non-test alerts use `--alert-channel`, defaulting to channel `0`.
+* National alerts bypass location filtering.
+* Non-national alerts are allowed when no location filter is configured.
+* When `--locations` is configured, at least one alert SAME location code must match.
+
+## Sender Model
+
+Sentinel uses a synchronous sender model with required and best-effort senders.
+
+```mermaid
+flowchart LR
+    A["Alert"] --> B["FanOut"]
+    B --> C["Required senders"]
+    B --> D["Best-effort senders"]
+    C --> E["MeshtasticSender"]
+    D --> F["DiscordSender, if configured"]
+    F --> G{"Failure?"}
+    G -->|yes, spool enabled| H["Append best-effort failure record"]
+    G -->|yes, no spool| I["Log and continue"]
+    E --> J{"Failure?"}
+    J -->|yes| K["Return failure"]
+```
+
+Required senders are part of the primary delivery path. If a required sender fails, fan-out returns an error. Best-effort senders are optional; their failures are logged and do not block required delivery.
+
+## Fan-Out Architecture
+
+`FanOut` owns two sender groups:
+
+* Required senders: must succeed for the alert send to be considered successful.
+* Best-effort senders: attempted after required senders and allowed to fail.
+
+The current implementation is synchronous. It does not use an async runtime, background worker, retry queue, or parallel dispatcher.
+
+## Meshtastic Role
+
+Meshtastic is the primary and required sender. It remains the default operational path for alert delivery.
+
+Current responsibilities:
+
+* Check Meshtastic readiness with the existing CLI behavior.
+* Preserve host and serial port options.
+* Preserve message chunking.
+* Preserve command construction and retry timing.
+* Send alert text to the selected Meshtastic channel.
+
+Meshtastic failures are not spooled in the current implementation.
+
+## Discord Role
+
+Discord is an optional best-effort sender. It is registered only when `--discord-webhook-url` is provided.
+
+Current responsibilities:
+
+* Send the formatted alert message to a Discord webhook.
+* Avoid logging the full webhook URL.
+* Fail without blocking Meshtastic delivery.
+
+Discord is network-dependent and is not part of Sentinel's offline-first primary path.
+
+## Failure Spool Role
+
+The failure spool is an opt-in durability aid for best-effort sender failures.
+
+Current behavior:
+
+* Disabled by default.
+* Enabled only with `--spool-path <PATH>`.
+* Appends deterministic one-line JSONL-style records.
+* Records failed best-effort sender attempts only.
+* Does not spool required Meshtastic failures.
+* Spool write failures are logged and do not block fan-out completion.
+
+The spool is not currently a replay queue, alert journal, or incident log.
+
+## Current Project Boundaries
+
+Sentinel currently includes:
+
+* NOAA SAME/EAS decoding from stdin audio.
+* SAME county/location filtering.
+* National alert override behavior.
+* Test alert routing behavior.
+* Synchronous sender/fan-out architecture.
+* Required Meshtastic sender.
+* Optional Discord webhook sender.
+* Optional best-effort failure spool.
+
+Sentinel does not currently include:
+
+* CAP ingestion.
+* Skywarn ingestion.
+* Reticulum/LXMF sending.
+* MeshCore sending.
+* Replay workers.
+* Dashboard or incident command UI.
+* ATAK interoperability.
+* Background processing.
+* Async runtime.
+
+## Planned Future Integrations
+
+These are intended evolution points, not current features.
+
+* Reticulum/LXMF: a future optional sender for resilient store-and-forward messaging.
+* MeshCore: a future optional sender for MeshCore-compatible networks.
+* Replay workers: future processing for retrying spooled best-effort failures.
+* Dashboard: a future Incident Command dashboard foundation for operator visibility.
+* Skywarn ingestion: a future pipeline for Skywarn-related inputs.
+* ATAK: future interoperability for tactical situational awareness workflows.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,46 @@
+# Sentinel Roadmap
+
+## Completed
+
+* [x] Phase 1 - Fan-out architecture
+* [x] Phase 1.1 - Hardening and regression testing
+* [x] Phase 2 - Optional Discord sender
+* [x] Phase 2.1 - Optional best-effort failure spool
+
+---
+
+## Planned
+
+* [ ] Phase 3 - Reticulum LXMF sender
+* [ ] Phase 4 - MeshCore sender
+* [ ] Phase 5 - Replay worker for spooled failures
+* [ ] Phase 6 - Incident Command dashboard foundation
+* [ ] Phase 7 - Skywarn ingestion pipeline
+* [ ] Phase 8 - ATAK interoperability
+* [ ] Phase 9 - Portable Sentinel deployment kits
+* [ ] Phase 10 - Sentinel Holy Grail platform
+
+---
+
+## Guiding Principles
+
+Sentinel will remain:
+
+* Offline-first
+* Modular
+* Open-source
+* Extensible
+* Operator-focused
+* Resilient during infrastructure failure
+* Usable in both community and industrial emergency response environments
+
+## Development Philosophy
+
+Sentinel favors:
+
+* Small milestones
+* Extensive testing
+* Offline-first operation
+* Minimal dependencies
+* Graceful degradation
+* Clear separation between implemented capabilities and future vision

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -46,6 +46,88 @@ impl Alert {
     }
 }
 
+pub struct AlertMessageParts<'a> {
+    pub event: &'a str,
+    pub significance: AlertSignificance,
+    pub originator: &'a str,
+    pub callsign: &'a str,
+    pub is_national: bool,
+    pub location_names: &'a [String],
+}
+
+pub fn alert_send_channel(
+    significance: AlertSignificance,
+    alert_channel: u32,
+    test_channel: u32,
+) -> Option<u32> {
+    if significance == AlertSignificance::Test {
+        if test_channel == 10 {
+            None
+        } else {
+            Some(test_channel)
+        }
+    } else {
+        Some(alert_channel)
+    }
+}
+
+pub fn location_filter_allows(
+    is_national: bool,
+    configured_locations: &[String],
+    alert_codes: &[String],
+) -> bool {
+    if is_national {
+        return true;
+    }
+
+    if !configured_locations.is_empty() && !alert_codes.is_empty() {
+        alert_codes
+            .iter()
+            .any(|code| configured_locations.contains(code))
+    } else {
+        true
+    }
+}
+
+pub fn format_alert_message(parts: AlertMessageParts<'_>) -> String {
+    let mut message = ", Issued By: ".to_string() + parts.originator;
+
+    match parts.significance {
+        AlertSignificance::Test => {
+            message =
+                "📖Received ".to_string() + parts.event + " from " + parts.callsign + &message;
+        }
+        AlertSignificance::Statement => {
+            message = "📟".to_string() + parts.event + &message;
+        }
+        AlertSignificance::Emergency => {
+            message = "🚨".to_string() + parts.event + &message;
+        }
+        AlertSignificance::Watch => {
+            message = "⚠️".to_string() + parts.event + &message;
+        }
+        AlertSignificance::Warning => {
+            message = "🚨".to_string() + parts.event + &message;
+        }
+        AlertSignificance::Unknown => {
+            message = "🚨".to_string() + parts.event + &message;
+        }
+    }
+
+    if parts.is_national {
+        message += " Nationwide Alert";
+    } else if !parts.location_names.is_empty() {
+        if parts.location_names.len() == 1 {
+            message.push_str(", Location: ");
+        } else {
+            message.push_str(", Locations: ");
+        }
+        message.push_str(&parts.location_names.join(", "));
+    }
+
+    message
+}
+
 pub fn chunk_message(message: &str, max_len: usize) -> Vec<String> {
     if message.is_empty() {
         return Vec::new();
@@ -78,6 +160,108 @@ pub fn chunk_message(message: &str, max_len: usize) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_alert_without_test_channel_is_not_routed() {
+        assert_eq!(alert_send_channel(AlertSignificance::Test, 0, 10), None);
+    }
+
+    #[test]
+    fn test_alert_with_test_channel_uses_test_channel() {
+        assert_eq!(alert_send_channel(AlertSignificance::Test, 0, 4), Some(4));
+    }
+
+    #[test]
+    fn non_test_alert_uses_alert_channel() {
+        assert_eq!(
+            alert_send_channel(AlertSignificance::Warning, 2, 4),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn national_alert_bypasses_location_filter() {
+        assert!(location_filter_allows(
+            true,
+            &[String::from("006085")],
+            &[String::from("048201")]
+        ));
+    }
+
+    #[test]
+    fn non_national_alert_requires_matching_location_when_filter_is_set() {
+        assert!(!location_filter_allows(
+            false,
+            &[String::from("006085")],
+            &[String::from("048201")]
+        ));
+        assert!(location_filter_allows(
+            false,
+            &[String::from("006085")],
+            &[String::from("006085")]
+        ));
+    }
+
+    #[test]
+    fn empty_location_filter_or_empty_alert_codes_allow_alert() {
+        assert!(location_filter_allows(
+            false,
+            &[],
+            &[String::from("006085")]
+        ));
+        assert!(location_filter_allows(
+            false,
+            &[String::from("006085")],
+            &[]
+        ));
+    }
+
+    #[test]
+    fn format_warning_with_single_location_matches_existing_output() {
+        let locations = vec![String::from("Central Santa Clara")];
+
+        assert_eq!(
+            format_alert_message(AlertMessageParts {
+                event: "Tornado Warning",
+                significance: AlertSignificance::Warning,
+                originator: "National Weather Service",
+                callsign: "KXYZ",
+                is_national: false,
+                location_names: &locations,
+            }),
+            "🚨Tornado Warning, Issued By: National Weather Service, Location: Central Santa Clara"
+        );
+    }
+
+    #[test]
+    fn format_test_alert_matches_existing_output() {
+        assert_eq!(
+            format_alert_message(AlertMessageParts {
+                event: "Required Weekly Test",
+                significance: AlertSignificance::Test,
+                originator: "National Weather Service",
+                callsign: "KXYZ",
+                is_national: false,
+                location_names: &[],
+            }),
+            "📖Received Required Weekly Test from KXYZ, Issued By: National Weather Service"
+        );
+    }
+
+    #[test]
+    fn format_national_alert_matches_existing_output() {
+        assert_eq!(
+            format_alert_message(AlertMessageParts {
+                event: "Emergency Action Notification",
+                significance: AlertSignificance::Emergency,
+                originator: "Primary Entry Point System",
+                callsign: "WXYZ",
+                is_national: true,
+                location_names: &[],
+            }),
+            "🚨Emergency Action Notification, Issued By: Primary Entry Point System Nationwide Alert"
+        );
+    }
 
     #[test]
     fn chunk_message_keeps_short_messages_whole() {

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -1,0 +1,94 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertSignificance {
+    Test,
+    Statement,
+    Emergency,
+    Watch,
+    Warning,
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Alert {
+    pub event: String,
+    pub significance: AlertSignificance,
+    pub originator: String,
+    pub callsign: String,
+    pub is_national: bool,
+    pub location_codes: Vec<String>,
+    pub location_names: Vec<String>,
+    pub message_text: String,
+    pub is_test: bool,
+}
+
+impl Alert {
+    pub fn new(
+        event: String,
+        significance: AlertSignificance,
+        originator: String,
+        callsign: String,
+        is_national: bool,
+        location_codes: Vec<String>,
+        location_names: Vec<String>,
+        message_text: String,
+    ) -> Self {
+        Self {
+            event,
+            significance,
+            originator,
+            callsign,
+            is_national,
+            location_codes,
+            location_names,
+            message_text,
+            is_test: significance == AlertSignificance::Test,
+        }
+    }
+}
+
+pub fn chunk_message(message: &str, max_len: usize) -> Vec<String> {
+    if message.is_empty() {
+        return Vec::new();
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    let mut current = 0;
+
+    for space in message.match_indices(' ').map(|(idx, _)| idx) {
+        if space.saturating_sub(start) > max_len {
+            if current > start {
+                chunks.push(message[start..current].to_string());
+                start = current;
+            }
+        }
+        current = space;
+    }
+
+    if start < message.len() {
+        chunks.push(message[start..].to_string());
+    }
+
+    chunks
+        .into_iter()
+        .filter(|chunk| !chunk.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chunk_message_keeps_short_messages_whole() {
+        assert_eq!(chunk_message("short alert", 75), vec!["short alert"]);
+    }
+
+    #[test]
+    fn chunk_message_splits_long_messages_without_empty_chunks() {
+        let chunks = chunk_message("one two three four five six seven", 13);
+
+        assert_eq!(chunks, vec!["one two three", " four five", " six seven"]);
+        assert!(chunks.iter().all(|chunk| !chunk.is_empty()));
+    }
+}

--- a/src/discord_sender.rs
+++ b/src/discord_sender.rs
@@ -1,0 +1,188 @@
+use crate::alert::Alert;
+use crate::sender::Sender;
+use anyhow::{anyhow, Result};
+
+const DISCORD_CONTENT_LIMIT: usize = 2000;
+const TRUNCATION_SUFFIX: &str = "\n...[truncated]";
+
+trait DiscordHttpClient {
+    fn post_json(&self, url: &str, body: &str) -> Result<()>;
+}
+
+struct UreqDiscordHttpClient;
+
+impl DiscordHttpClient for UreqDiscordHttpClient {
+    fn post_json(&self, url: &str, body: &str) -> Result<()> {
+        match ureq::post(url)
+            .set("Content-Type", "application/json")
+            .send_string(body)
+        {
+            Ok(_) => Ok(()),
+            Err(ureq::Error::Status(status, _)) => Err(anyhow!(
+                "Discord webhook POST failed with status {}",
+                status
+            )),
+            Err(ureq::Error::Transport(_)) => Err(anyhow!("Discord webhook POST failed")),
+        }
+    }
+}
+
+pub struct DiscordSender {
+    webhook_url: String,
+    client: Box<dyn DiscordHttpClient>,
+}
+
+impl DiscordSender {
+    pub fn new(webhook_url: String) -> Self {
+        Self::with_client(webhook_url, Box::new(UreqDiscordHttpClient))
+    }
+
+    fn with_client(webhook_url: String, client: Box<dyn DiscordHttpClient>) -> Self {
+        Self {
+            webhook_url,
+            client,
+        }
+    }
+}
+
+impl Sender for DiscordSender {
+    fn check_ready(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn send_alert(&mut self, alert: &Alert, _channel: u32) -> Result<()> {
+        let content = truncate_discord_content(&alert.message_text);
+        let payload = discord_payload(&content);
+        self.client.post_json(&self.webhook_url, &payload)
+    }
+}
+
+fn discord_payload(content: &str) -> String {
+    format!(r#"{{"content":"{}"}}"#, json_escape(content))
+}
+
+fn truncate_discord_content(content: &str) -> String {
+    if content.chars().count() <= DISCORD_CONTENT_LIMIT {
+        return content.to_string();
+    }
+
+    let keep = DISCORD_CONTENT_LIMIT - TRUNCATION_SUFFIX.chars().count();
+    let mut truncated: String = content.chars().take(keep).collect();
+    truncated.push_str(TRUNCATION_SUFFIX);
+    truncated
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::new();
+
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            c if c.is_control() => escaped.push_str(&format!("\\u{:04x}", c as u32)),
+            c => escaped.push(c),
+        }
+    }
+
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alert::AlertSignificance;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    struct RecordingDiscordHttpClient {
+        requests: Rc<RefCell<Vec<(String, String)>>>,
+        error: Option<&'static str>,
+    }
+
+    impl DiscordHttpClient for RecordingDiscordHttpClient {
+        fn post_json(&self, url: &str, body: &str) -> Result<()> {
+            self.requests
+                .borrow_mut()
+                .push((url.to_string(), body.to_string()));
+
+            if let Some(error) = self.error {
+                Err(anyhow!(error))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn test_alert(message_text: String) -> Alert {
+        Alert::new(
+            "Tornado Warning".to_string(),
+            AlertSignificance::Warning,
+            "National Weather Service".to_string(),
+            "KXYZ".to_string(),
+            false,
+            Vec::new(),
+            Vec::new(),
+            message_text,
+        )
+    }
+
+    #[test]
+    fn discord_payload_uses_alert_message_text_as_content() {
+        let requests = Rc::new(RefCell::new(Vec::new()));
+        let mut sender = DiscordSender::with_client(
+            "https://discord.example/webhook".to_string(),
+            Box::new(RecordingDiscordHttpClient {
+                requests: Rc::clone(&requests),
+                error: None,
+            }),
+        );
+
+        sender
+            .send_alert(&test_alert("alert text".to_string()), 0)
+            .unwrap();
+
+        assert_eq!(
+            *requests.borrow(),
+            vec![(
+                "https://discord.example/webhook".to_string(),
+                r#"{"content":"alert text"}"#.to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn discord_payload_escapes_json_content() {
+        assert_eq!(
+            discord_payload("line 1\n\"quoted\" \\ path"),
+            r#"{"content":"line 1\n\"quoted\" \\ path"}"#
+        );
+    }
+
+    #[test]
+    fn discord_content_is_truncated_to_limit_with_suffix() {
+        let content = truncate_discord_content(&"x".repeat(DISCORD_CONTENT_LIMIT + 1));
+
+        assert_eq!(content.chars().count(), DISCORD_CONTENT_LIMIT);
+        assert!(content.ends_with(TRUNCATION_SUFFIX));
+    }
+
+    #[test]
+    fn discord_send_errors_are_returned_to_best_effort_fanout() {
+        let requests = Rc::new(RefCell::new(Vec::new()));
+        let mut sender = DiscordSender::with_client(
+            "https://discord.example/webhook".to_string(),
+            Box::new(RecordingDiscordHttpClient {
+                requests: Rc::clone(&requests),
+                error: Some("send failed"),
+            }),
+        );
+
+        assert!(sender
+            .send_alert(&test_alert("alert text".to_string()), 0)
+            .is_err());
+        assert_eq!(requests.borrow().len(), 1);
+    }
+}

--- a/src/discord_sender.rs
+++ b/src/discord_sender.rs
@@ -46,6 +46,10 @@ impl DiscordSender {
 }
 
 impl Sender for DiscordSender {
+    fn name(&self) -> &'static str {
+        "discord"
+    }
+
     fn check_ready(&self) -> Result<()> {
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod alert;
+mod discord_sender;
 mod meshtastic_sender;
 mod sender;
 
@@ -10,11 +11,12 @@ use anyhow::Result;
 use byteorder::{NativeEndian, ReadBytesExt};
 use clap::Parser;
 use csv::ReaderBuilder;
+use discord_sender::DiscordSender;
 use log::LevelFilter;
 use meshtastic_sender::{MeshtasticConfig, MeshtasticSender};
 use rust_embed::RustEmbed;
 use sameold::{Message, SameReceiverBuilder, SignificanceLevel};
-use sender::FanOut;
+use sender::{FanOut, Sender};
 use serde::Deserialize;
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
@@ -117,6 +119,26 @@ struct Args {
     /// Location codes that must be present to send an alert
     #[arg(long, short, value_delimiter = ',', default_value = None, required = false)]
     locations: Vec<String>,
+
+    /// Optional Discord webhook URL for best-effort alert delivery
+    #[arg(long)]
+    discord_webhook_url: Option<String>,
+}
+
+fn build_fanout(args: &Args) -> FanOut {
+    let required_senders: Vec<Box<dyn Sender>> =
+        vec![Box::new(MeshtasticSender::new(MeshtasticConfig {
+            host: args.host.clone(),
+            port: args.port.clone(),
+        }))];
+    let mut best_effort_senders: Vec<Box<dyn Sender>> = Vec::new();
+
+    if let Some(webhook_url) = &args.discord_webhook_url {
+        best_effort_senders.push(Box::new(DiscordSender::new(webhook_url.clone())));
+        FanOut::with_best_effort(required_senders, best_effort_senders)
+    } else {
+        FanOut::new(required_senders)
+    }
 }
 
 fn main() -> Result<()> {
@@ -157,10 +179,7 @@ fn main() -> Result<()> {
         }
     }
 
-    let mut fanout = FanOut::new(vec![Box::new(MeshtasticSender::new(MeshtasticConfig {
-        host: args.host.clone(),
-        port: args.port.clone(),
-    }))]);
+    let mut fanout = build_fanout(&args);
 
     if let Err(e) = fanout.check_ready() {
         log::error!("{}", e);
@@ -289,4 +308,32 @@ fn main() -> Result<()> {
     log::warn!("Program stopped, no longer monitoring");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fanout_registers_only_meshtastic_without_discord_webhook() {
+        let args = Args::try_parse_from(["alerter"]).unwrap();
+        let fanout = build_fanout(&args);
+
+        assert_eq!(fanout.required_sender_count(), 1);
+        assert_eq!(fanout.best_effort_sender_count(), 0);
+    }
+
+    #[test]
+    fn fanout_registers_discord_as_best_effort_when_webhook_is_provided() {
+        let args = Args::try_parse_from([
+            "alerter",
+            "--discord-webhook-url",
+            "https://discord.example/webhook",
+        ])
+        .unwrap();
+        let fanout = build_fanout(&args);
+
+        assert_eq!(fanout.required_sender_count(), 1);
+        assert_eq!(fanout.best_effort_sender_count(), 1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod alert;
 mod discord_sender;
 mod meshtastic_sender;
 mod sender;
+mod spool;
 
 use alert::{
     alert_send_channel, format_alert_message, location_filter_allows, Alert, AlertMessageParts,
@@ -19,8 +20,10 @@ use sameold::{Message, SameReceiverBuilder, SignificanceLevel};
 use sender::{FanOut, Sender};
 use serde::Deserialize;
 use simple_logger::SimpleLogger;
+use spool::FileSpooler;
 use std::collections::HashMap;
 use std::io::{self};
+use std::path::PathBuf;
 use strum::EnumMessage;
 
 #[derive(RustEmbed)]
@@ -123,6 +126,10 @@ struct Args {
     /// Optional Discord webhook URL for best-effort alert delivery
     #[arg(long)]
     discord_webhook_url: Option<String>,
+
+    /// Optional JSONL path for spooling best-effort sender failures
+    #[arg(long)]
+    spool_path: Option<PathBuf>,
 }
 
 fn build_fanout(args: &Args) -> FanOut {
@@ -133,12 +140,18 @@ fn build_fanout(args: &Args) -> FanOut {
         }))];
     let mut best_effort_senders: Vec<Box<dyn Sender>> = Vec::new();
 
-    if let Some(webhook_url) = &args.discord_webhook_url {
+    let mut fanout = if let Some(webhook_url) = &args.discord_webhook_url {
         best_effort_senders.push(Box::new(DiscordSender::new(webhook_url.clone())));
         FanOut::with_best_effort(required_senders, best_effort_senders)
     } else {
         FanOut::new(required_senders)
+    };
+
+    if let Some(spool_path) = &args.spool_path {
+        fanout = fanout.with_spooler(Box::new(FileSpooler::new(spool_path.clone())));
     }
+
+    fanout
 }
 
 fn main() -> Result<()> {
@@ -335,5 +348,23 @@ mod tests {
 
         assert_eq!(fanout.required_sender_count(), 1);
         assert_eq!(fanout.best_effort_sender_count(), 1);
+    }
+
+    #[test]
+    fn fanout_has_no_spooler_without_spool_path() {
+        let args = Args::try_parse_from(["alerter"]).unwrap();
+        let fanout = build_fanout(&args);
+
+        assert!(!fanout.has_spooler());
+    }
+
+    #[test]
+    fn fanout_configures_spooler_when_spool_path_is_provided() {
+        let args = Args::try_parse_from(["alerter", "--spool-path", "failed-sends.jsonl"]).unwrap();
+        let fanout = build_fanout(&args);
+
+        assert!(fanout.has_spooler());
+        assert_eq!(fanout.required_sender_count(), 1);
+        assert_eq!(fanout.best_effort_sender_count(), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,21 @@
+mod alert;
+mod meshtastic_sender;
+mod sender;
+
+use alert::{Alert, AlertSignificance};
 use anyhow::Result;
 use byteorder::{NativeEndian, ReadBytesExt};
-use csv::ReaderBuilder;
-use log::{info, LevelFilter, log};
-use rust_embed::RustEmbed;
 use clap::Parser;
+use csv::ReaderBuilder;
+use log::LevelFilter;
+use meshtastic_sender::{MeshtasticConfig, MeshtasticSender};
+use rust_embed::RustEmbed;
 use sameold::{Message, SameReceiverBuilder, SignificanceLevel};
+use sender::FanOut;
 use serde::Deserialize;
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
-use std::env::args;
 use std::io::{self};
-use std::time::{Duration, Instant};
-use tokio::time::sleep;
-use std::process::{Command, Stdio};
 use strum::EnumMessage;
 
 #[derive(RustEmbed)]
@@ -26,144 +29,7 @@ struct Record {
     state: String,
 }
 
-struct MessageSender {
-    last_message_time: Option<Instant>,
-}
-
-impl MessageSender {
-    fn new() -> Self {
-        MessageSender {
-            last_message_time: None,
-        }
-    }
-
-    async fn send_message_with_retry(
-        &mut self,
-        chan: u32,
-        message: &str,
-        retries: u32,
-        delay: Duration,
-        args: Args,
-    ) -> Result<(), String> {
-        // Ensure at least 20 seconds between messages
-        if let Some(last_time) = self.last_message_time {
-            let elapsed = last_time.elapsed();
-            if elapsed < Duration::from_secs(20) {
-                sleep(Duration::from_secs(20) - elapsed).await;
-            }
-        }
-
-        for attempt in 0..=retries {
-            // Create a new Command instance
-            let mut command = Command::new("meshtastic");
-                command.arg("--no-nodes");
-                command.arg("--no-time");
-                command.arg("--ch-index");
-                command.arg(chan.to_string());
-                command.arg("--sendtext");
-                command.arg(message.to_string()); // Convert message to String to extend its lifetime
-                command.arg("--ack");
-
-            // Conditionally add the host argument if provided
-            if let Some(host) = &args.host {
-                command.arg("--host").arg(host);
-            }
-            
-            // Conditionally add the port argument if provided
-            if let Some(port) = &args.port {
-                command.arg("--port").arg(port);
-            }
-
-            // Execute the command
-            let result = command.spawn();
-
-            match result {
-                Ok(_) => {
-                    self.last_message_time = Some(Instant::now());
-                    return Ok(());
-                }
-                Err(e) => {
-                    if attempt < retries {
-                        log::warn!("Error sending message: {}. Retrying in {:?}...", e, delay);
-                        sleep(delay).await;
-                    } else {
-                        log::error!("Error sending message after {} attempts: {}", retries, e);
-                        return Err(format!("Failed to send message: {}", e));
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-
-
-}
-
-async fn check_node_connection(args: Args) -> Result<()> {
-    // Construct the command to run `meshtastic --info`
-    let mut cmd = Command::new("meshtastic");
-
-
-
-    // Conditionally add the "--host" argument if the host is provided
-    if let Some(host) = &args.host {
-        cmd.arg("--host");
-        cmd.arg(host);  // Add host argument here
-    }
-
-    // Conditionally add the "--port" argument if the serial port is provided ie. /dev/ttyUSB0
-    if let Some(port) = &args.port {
-        cmd.arg("--port");
-        cmd.arg(port);  // Add port argument here
-    }
-
-
-    // Add the --info argument
-    cmd.arg("--info");
-
-    // Ensure the command doesn't output to the console
-    cmd.stdout(Stdio::piped());
-
-    // Run the command and capture the output
-    let output = cmd.output();
-
-    match output {
-        Ok(output) => {
-            // Convert the stdout to a string (output is captured as bytes)
-            let stdout = String::from_utf8_lossy(&output.stdout);
-
-            // Check if the output contains "Error"
-            if stdout.contains("Error") {
-                log::error!("Received error output: {}", stdout);
-                std::process::exit(1);
-            }
-
-
-            // Check the first line of the output
-            if let Some(first_line) = stdout.lines().next() {
-                if first_line == "Connected to radio" {
-                    log::info!("Successfully connected to the node.");
-                    return Ok(());
-                } else {
-                    log::error!("Failed to connect to the radio. First line: {}", first_line);
-                    std::process::exit(1);
-                }
-            } else {
-                log::error!("Output from meshtastic --info was empty.");
-                std::process::exit(1);
-            }
-        }
-        Err(e) => {
-            // Log error if the command failed to run
-            log::error!("Failed to execute meshtastic --info: {}", e);
-            std::process::exit(1);
-        }
-    }
-
-}
-
-async fn load_csv_into_hashmap() -> HashMap<String, (String, String)> {
+fn load_csv_into_hashmap() -> HashMap<String, (String, String)> {
     let mut map = HashMap::new();
 
     let csv_data = Asset::get("sameCodes.csv").unwrap();
@@ -181,7 +47,6 @@ async fn load_csv_into_hashmap() -> HashMap<String, (String, String)> {
     map
 }
 
-
 fn search_by_code<'a>(
     map: &'a HashMap<String, (String, String)>,
     code: &str,
@@ -189,7 +54,41 @@ fn search_by_code<'a>(
     map.get(code)
 }
 
-#[derive(Parser, Debug)]
+fn alert_significance(significance: SignificanceLevel) -> AlertSignificance {
+    match significance {
+        SignificanceLevel::Test => AlertSignificance::Test,
+        SignificanceLevel::Statement => AlertSignificance::Statement,
+        SignificanceLevel::Emergency => AlertSignificance::Emergency,
+        SignificanceLevel::Watch => AlertSignificance::Watch,
+        SignificanceLevel::Warning => AlertSignificance::Warning,
+        SignificanceLevel::Unknown => AlertSignificance::Unknown,
+    }
+}
+
+fn location_name(map: &HashMap<String, (String, String)>, code: &str) -> Option<String> {
+    search_by_code(map, &format!("0{}", &code[1..])).map(|(county, _state)| {
+        let mut location = String::new();
+
+        match code.chars().next().unwrap_or_default() {
+            '0' => {}
+            '1' => location.push_str("Northwest "),
+            '2' => location.push_str("North "),
+            '3' => location.push_str("Northeast "),
+            '4' => location.push_str("West "),
+            '5' => location.push_str("Central "),
+            '6' => location.push_str("East "),
+            '7' => location.push_str("Southwest "),
+            '8' => location.push_str("South "),
+            '9' => location.push_str("Southeast "),
+            _ => {}
+        }
+
+        location.push_str(county);
+        location
+    })
+}
+
+#[derive(Parser, Debug, Clone)]
 #[command(long_about = None)]
 struct Args {
     /// Channel to which alerts are sent to, if not provided will default to channel 0
@@ -215,11 +114,9 @@ struct Args {
     /// Location codes that must be present to send an alert
     #[arg(long, short, value_delimiter = ',', default_value = None, required = false)]
     locations: Vec<String>,
-
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     // Initialize logging
     SimpleLogger::new()
         .with_level(LevelFilter::Off)
@@ -236,7 +133,6 @@ async fn main() -> Result<()> {
 
     // Parse the command line arguments
     let args = Args::parse();
-
 
     // Handle alertChannel argument
     if let Some(alert_channel_arg) = args.alert_channel {
@@ -258,7 +154,15 @@ async fn main() -> Result<()> {
         }
     }
 
-    check_node_connection(Args::parse()).await.expect("Failed to check node connection");
+    let mut fanout = FanOut::new(vec![Box::new(MeshtasticSender::new(MeshtasticConfig {
+        host: args.host.clone(),
+        port: args.port.clone(),
+    }))]);
+
+    if let Err(e) = fanout.check_ready() {
+        log::error!("{}", e);
+        std::process::exit(1);
+    }
 
     // Create a SameReceiver.
     let mut rx = SameReceiverBuilder::new(args.rate)
@@ -276,7 +180,7 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    let map = load_csv_into_hashmap().await;
+    let map = load_csv_into_hashmap();
     log::info!("Loaded locations CSV");
 
     let stdin_handle = stdin.lock();
@@ -284,8 +188,6 @@ async fn main() -> Result<()> {
 
     // Create an iterator for audio source from stdin, reading i16 and converting to f32
     let audiosrc = std::iter::from_fn(|| inbuf.read_i16::<NativeEndian>().ok());
-
-    let mut sender = MessageSender::new();
 
     log::info!("Monitoring for alerts");
     log::info!("Alerts will be sent to channel: {}", alert_channel);
@@ -303,9 +205,11 @@ async fn main() -> Result<()> {
                 log::info!("Begin SAME voice message: {:?}", hdr);
                 let mut message: String;
                 let mut send_channel: u32 = alert_channel;
+                let codes: Vec<String> = hdr.location_str_iter().map(|s| s.to_string()).collect();
+                let mut locations_found = Vec::new();
 
-                message = ", Issued By: ".to_string()
-                    + hdr.originator().get_detailed_message().unwrap();
+                message =
+                    ", Issued By: ".to_string() + hdr.originator().get_detailed_message().unwrap();
                 match evt.significance() {
                     SignificanceLevel::Test => {
                         send_channel = test_channel;
@@ -335,7 +239,6 @@ async fn main() -> Result<()> {
                         message = "🚨".to_string() + &evt.to_string() + &*message;
                     }
                 }
-                let codes: Vec<String> = hdr.location_str_iter().map(|s| s.to_string()).collect();
 
                 if hdr.is_national() {
                     message += " Nationwide Alert"
@@ -347,7 +250,11 @@ async fn main() -> Result<()> {
 
                         let has_match = codes.iter().any(|code| {
                             let matches = args.locations.contains(code);
-                            log::debug!("Comparing alert code '{}' with provided locations: {}", code, matches);
+                            log::debug!(
+                                "Comparing alert code '{}' with provided locations: {}",
+                                code,
+                                matches
+                            );
                             matches
                         });
 
@@ -358,35 +265,14 @@ async fn main() -> Result<()> {
                             log::info!("Alert has matching locations, proceeding to send");
                         }
                     } else {
-                        log::info!("No location filter applied (locations empty) or no locations in alert");
+                        log::info!(
+                            "No location filter applied (locations empty) or no locations in alert"
+                        );
                     }
 
-                    let mut locations_found = Vec::new();
-
                     // Pass each code into the function and collect the results
-                    for code in codes {
-                        if let Some((county, _state)) =
-                            search_by_code(&map, &format!("0{}", &code[1..]))
-                        {
-                            let mut location = String::new();
-
-                            // Determining where in the county the location is
-                            // https://www.weather.gov/nwr/sameenz
-                            match code.chars().next().unwrap_or_default() {
-                                '0' => {}
-                                '1' => location.push_str("Northwest "),
-                                '2' => location.push_str("North "),
-                                '3' => location.push_str("Northeast "),
-                                '4' => location.push_str("West "),
-                                '5' => location.push_str("Central "),
-                                '6' => location.push_str("East "),
-                                '7' => location.push_str("Southwest "),
-                                '8' => location.push_str("South "),
-                                '9' => location.push_str("Southeast "),
-                                _ => {}
-                            }
-
-                            location.push_str(county);
+                    for code in &codes {
+                        if let Some(location) = location_name(&map, code) {
                             locations_found.push(location);
                         } else {
                             log::debug!("Location Code: {} not found", code);
@@ -405,30 +291,20 @@ async fn main() -> Result<()> {
 
                 log::info!("Attempting to send message over the mesh: {}", message);
 
-                // Split and send the message in chunks of 75 characters, using retry logic
-                let mut myvec: Vec<usize> = message.bytes().enumerate().filter(|(_,c)| *c == b' ').map(|(i,_)| i).collect::<Vec<_>>();
-                let mut curpos: usize = 0;
-                let mut curlen: usize = 0;
-                let mut startpos: usize = 0;
-                for i in myvec.iter_mut() {
-                    if curlen + *i - curpos > 75 {
-                        sender
-                            .send_message_with_retry(send_channel, &message[startpos..(startpos + curlen)], 3, Duration::from_secs(5), Args::parse())
-                            .await.expect("Failed sending msg");
-                        curpos = startpos + curlen;
-                        startpos += curlen;
-                        curlen = 0;
-                    } else {
-                        curlen += *i - curpos;
-                        curpos = *i;
-                    }
-                }
-                curlen = message.len() - startpos;
-                if curlen != 0 {
-                    sender
-                        .send_message_with_retry(send_channel, &message[startpos..(startpos + curlen)], 3, Duration::from_secs(5), Args::parse())
-                        .await.expect("Failed sending msg");
-                }
+                let alert = Alert::new(
+                    evt.to_string(),
+                    alert_significance(evt.significance()),
+                    hdr.originator().get_detailed_message().unwrap().to_string(),
+                    hdr.callsign().to_string(),
+                    hdr.is_national(),
+                    codes,
+                    locations_found,
+                    message,
+                );
+
+                fanout
+                    .send_alert(&alert, send_channel)
+                    .expect("Failed sending msg");
             }
             Message::EndOfMessage => {
                 log::info!("End SAME voice message");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ mod alert;
 mod meshtastic_sender;
 mod sender;
 
-use alert::{Alert, AlertSignificance};
+use alert::{
+    alert_send_channel, format_alert_message, location_filter_allows, Alert, AlertMessageParts,
+    AlertSignificance,
+};
 use anyhow::Result;
 use byteorder::{NativeEndian, ReadBytesExt};
 use clap::Parser;
@@ -202,63 +205,34 @@ fn main() -> Result<()> {
         match msg {
             Message::StartOfMessage(hdr) => {
                 let evt = hdr.event();
+                let significance = alert_significance(evt.significance());
                 log::info!("Begin SAME voice message: {:?}", hdr);
-                let mut message: String;
-                let mut send_channel: u32 = alert_channel;
                 let codes: Vec<String> = hdr.location_str_iter().map(|s| s.to_string()).collect();
                 let mut locations_found = Vec::new();
 
-                message =
-                    ", Issued By: ".to_string() + hdr.originator().get_detailed_message().unwrap();
-                match evt.significance() {
-                    SignificanceLevel::Test => {
-                        send_channel = test_channel;
-                        if test_channel == 10 {
-                            log::info!("Ignoring test alert");
-                            continue;
-                        }
-                        message = "📖Received ".to_string()
-                            + &evt.to_string()
-                            + " from "
-                            + hdr.callsign()
-                            + &*message;
-                    }
-                    SignificanceLevel::Statement => {
-                        message = "📟".to_string() + &evt.to_string() + &*message;
-                    }
-                    SignificanceLevel::Emergency => {
-                        message = "🚨".to_string() + &evt.to_string() + &*message;
-                    }
-                    SignificanceLevel::Watch => {
-                        message = "⚠️".to_string() + &evt.to_string() + &*message;
-                    }
-                    SignificanceLevel::Warning => {
-                        message = "🚨".to_string() + &evt.to_string() + &*message;
-                    }
-                    SignificanceLevel::Unknown => {
-                        message = "🚨".to_string() + &evt.to_string() + &*message;
-                    }
-                }
+                let Some(send_channel) =
+                    alert_send_channel(significance, alert_channel, test_channel)
+                else {
+                    log::info!("Ignoring test alert");
+                    continue;
+                };
 
-                if hdr.is_national() {
-                    message += " Nationwide Alert"
-                } else {
+                if !hdr.is_national() {
                     if !args.locations.is_empty() && !codes.is_empty() {
                         // Log the values for debugging
                         log::debug!("Provided locations: {:?}", args.locations);
                         log::debug!("Alert locations: {:?}", codes);
 
-                        let has_match = codes.iter().any(|code| {
+                        for code in &codes {
                             let matches = args.locations.contains(code);
                             log::debug!(
                                 "Comparing alert code '{}' with provided locations: {}",
                                 code,
                                 matches
                             );
-                            matches
-                        });
+                        }
 
-                        if !has_match {
+                        if !location_filter_allows(hdr.is_national(), &args.locations, &codes) {
                             log::info!("Ignoring alert with no matching locations in filter");
                             continue;
                         } else {
@@ -278,22 +252,22 @@ fn main() -> Result<()> {
                             log::debug!("Location Code: {} not found", code);
                         }
                     }
-
-                    if !locations_found.is_empty() {
-                        if locations_found.len() == 1 {
-                            message.push_str(", Location: ");
-                        } else {
-                            message.push_str(", Locations: ");
-                        }
-                        message.push_str(&locations_found.join(", "));
-                    }
                 }
+
+                let message = format_alert_message(AlertMessageParts {
+                    event: &evt.to_string(),
+                    significance,
+                    originator: hdr.originator().get_detailed_message().unwrap(),
+                    callsign: hdr.callsign(),
+                    is_national: hdr.is_national(),
+                    location_names: &locations_found,
+                });
 
                 log::info!("Attempting to send message over the mesh: {}", message);
 
                 let alert = Alert::new(
                     evt.to_string(),
-                    alert_significance(evt.significance()),
+                    significance,
                     hdr.originator().get_detailed_message().unwrap().to_string(),
                     hdr.callsign().to_string(),
                     hdr.is_national(),

--- a/src/meshtastic_sender.rs
+++ b/src/meshtastic_sender.rs
@@ -1,0 +1,214 @@
+use crate::alert::{chunk_message, Alert};
+use crate::sender::Sender;
+use anyhow::{anyhow, Result};
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MeshtasticConfig {
+    pub host: Option<String>,
+    pub port: Option<String>,
+}
+
+pub struct MeshtasticSender {
+    config: MeshtasticConfig,
+    last_message_time: Option<Instant>,
+}
+
+impl MeshtasticSender {
+    pub fn new(config: MeshtasticConfig) -> Self {
+        Self {
+            config,
+            last_message_time: None,
+        }
+    }
+
+    fn info_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+
+        if let Some(host) = &self.config.host {
+            args.push("--host".to_string());
+            args.push(host.clone());
+        }
+
+        if let Some(port) = &self.config.port {
+            args.push("--port".to_string());
+            args.push(port.clone());
+        }
+
+        args.push("--info".to_string());
+        args
+    }
+
+    fn send_args(&self, chan: u32, message: &str) -> Vec<String> {
+        let mut args = vec![
+            "--no-nodes".to_string(),
+            "--no-time".to_string(),
+            "--ch-index".to_string(),
+            chan.to_string(),
+            "--sendtext".to_string(),
+            message.to_string(),
+            "--ack".to_string(),
+        ];
+
+        if let Some(host) = &self.config.host {
+            args.push("--host".to_string());
+            args.push(host.clone());
+        }
+
+        if let Some(port) = &self.config.port {
+            args.push("--port".to_string());
+            args.push(port.clone());
+        }
+
+        args
+    }
+
+    fn send_message_with_retry(
+        &mut self,
+        chan: u32,
+        message: &str,
+        retries: u32,
+        delay: Duration,
+    ) -> Result<()> {
+        if let Some(last_time) = self.last_message_time {
+            let elapsed = last_time.elapsed();
+            if elapsed < Duration::from_secs(20) {
+                sleep(Duration::from_secs(20) - elapsed);
+            }
+        }
+
+        for attempt in 0..=retries {
+            let result = Command::new("meshtastic")
+                .args(self.send_args(chan, message))
+                .spawn();
+
+            match result {
+                Ok(_) => {
+                    self.last_message_time = Some(Instant::now());
+                    return Ok(());
+                }
+                Err(e) => {
+                    if attempt < retries {
+                        log::warn!("Error sending message: {}. Retrying in {:?}...", e, delay);
+                        sleep(delay);
+                    } else {
+                        log::error!("Error sending message after {} attempts: {}", retries, e);
+                        return Err(anyhow!("Failed to send message: {}", e));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Sender for MeshtasticSender {
+    fn check_ready(&self) -> Result<()> {
+        let output = Command::new("meshtastic")
+            .args(self.info_args())
+            .stdout(Stdio::piped())
+            .output()
+            .map_err(|e| anyhow!("Failed to execute meshtastic --info: {}", e))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+
+        if stdout.contains("Error") {
+            return Err(anyhow!("Received error output: {}", stdout));
+        }
+
+        if let Some(first_line) = stdout.lines().next() {
+            if first_line == "Connected to radio" {
+                log::info!("Successfully connected to the node.");
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "Failed to connect to the radio. First line: {}",
+                    first_line
+                ))
+            }
+        } else {
+            Err(anyhow!("Output from meshtastic --info was empty."))
+        }
+    }
+
+    fn send_alert(&mut self, alert: &Alert, channel: u32) -> Result<()> {
+        for chunk in chunk_message(&alert.message_text, 75) {
+            self.send_message_with_retry(channel, &chunk, 3, Duration::from_secs(5))?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn info_args_include_host_and_port_when_configured() {
+        let sender = MeshtasticSender::new(MeshtasticConfig {
+            host: Some("192.0.2.1:4403".to_string()),
+            port: Some("/dev/ttyUSB0".to_string()),
+        });
+
+        assert_eq!(
+            sender.info_args(),
+            vec![
+                "--host",
+                "192.0.2.1:4403",
+                "--port",
+                "/dev/ttyUSB0",
+                "--info"
+            ]
+        );
+    }
+
+    #[test]
+    fn send_args_match_existing_meshtastic_cli_flags() {
+        let sender = MeshtasticSender::new(MeshtasticConfig {
+            host: None,
+            port: None,
+        });
+
+        assert_eq!(
+            sender.send_args(2, "alert text"),
+            vec![
+                "--no-nodes",
+                "--no-time",
+                "--ch-index",
+                "2",
+                "--sendtext",
+                "alert text",
+                "--ack"
+            ]
+        );
+    }
+
+    #[test]
+    fn send_args_append_optional_host_and_port() {
+        let sender = MeshtasticSender::new(MeshtasticConfig {
+            host: Some("mesh.local:4403".to_string()),
+            port: Some("/dev/ttyUSB0".to_string()),
+        });
+
+        assert_eq!(
+            sender.send_args(1, "alert text"),
+            vec![
+                "--no-nodes",
+                "--no-time",
+                "--ch-index",
+                "1",
+                "--sendtext",
+                "alert text",
+                "--ack",
+                "--host",
+                "mesh.local:4403",
+                "--port",
+                "/dev/ttyUSB0"
+            ]
+        );
+    }
+}

--- a/src/meshtastic_sender.rs
+++ b/src/meshtastic_sender.rs
@@ -1,9 +1,37 @@
 use crate::alert::{chunk_message, Alert};
 use crate::sender::Sender;
 use anyhow::{anyhow, Result};
+use std::io;
 use std::process::{Command, Stdio};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
+
+struct CommandOutput {
+    stdout: Vec<u8>,
+}
+
+trait CommandRunner {
+    fn output(&self, program: &str, args: &[String]) -> io::Result<CommandOutput>;
+    fn spawn(&self, program: &str, args: &[String]) -> io::Result<()>;
+}
+
+struct RealCommandRunner;
+
+impl CommandRunner for RealCommandRunner {
+    fn output(&self, program: &str, args: &[String]) -> io::Result<CommandOutput> {
+        Command::new(program)
+            .args(args)
+            .stdout(Stdio::piped())
+            .output()
+            .map(|output| CommandOutput {
+                stdout: output.stdout,
+            })
+    }
+
+    fn spawn(&self, program: &str, args: &[String]) -> io::Result<()> {
+        Command::new(program).args(args).spawn().map(|_| ())
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MeshtasticConfig {
@@ -14,13 +42,19 @@ pub struct MeshtasticConfig {
 pub struct MeshtasticSender {
     config: MeshtasticConfig,
     last_message_time: Option<Instant>,
+    runner: Box<dyn CommandRunner>,
 }
 
 impl MeshtasticSender {
     pub fn new(config: MeshtasticConfig) -> Self {
+        Self::with_runner(config, Box::new(RealCommandRunner))
+    }
+
+    fn with_runner(config: MeshtasticConfig, runner: Box<dyn CommandRunner>) -> Self {
         Self {
             config,
             last_message_time: None,
+            runner,
         }
     }
 
@@ -80,9 +114,9 @@ impl MeshtasticSender {
         }
 
         for attempt in 0..=retries {
-            let result = Command::new("meshtastic")
-                .args(self.send_args(chan, message))
-                .spawn();
+            let result = self
+                .runner
+                .spawn("meshtastic", &self.send_args(chan, message));
 
             match result {
                 Ok(_) => {
@@ -107,10 +141,9 @@ impl MeshtasticSender {
 
 impl Sender for MeshtasticSender {
     fn check_ready(&self) -> Result<()> {
-        let output = Command::new("meshtastic")
-            .args(self.info_args())
-            .stdout(Stdio::piped())
-            .output()
+        let output = self
+            .runner
+            .output("meshtastic", &self.info_args())
             .map_err(|e| anyhow!("Failed to execute meshtastic --info: {}", e))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -146,6 +179,41 @@ impl Sender for MeshtasticSender {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct RecordedCommand {
+        program: String,
+        args: Vec<String>,
+    }
+
+    struct RecordingCommandRunner {
+        commands: Rc<RefCell<Vec<RecordedCommand>>>,
+        stdout: Vec<u8>,
+    }
+
+    impl CommandRunner for RecordingCommandRunner {
+        fn output(&self, program: &str, args: &[String]) -> io::Result<CommandOutput> {
+            self.commands.borrow_mut().push(RecordedCommand {
+                program: program.to_string(),
+                args: args.to_vec(),
+            });
+
+            Ok(CommandOutput {
+                stdout: self.stdout.clone(),
+            })
+        }
+
+        fn spawn(&self, program: &str, args: &[String]) -> io::Result<()> {
+            self.commands.borrow_mut().push(RecordedCommand {
+                program: program.to_string(),
+                args: args.to_vec(),
+            });
+
+            Ok(())
+        }
+    }
 
     #[test]
     fn info_args_include_host_and_port_when_configured() {
@@ -209,6 +277,82 @@ mod tests {
                 "--port",
                 "/dev/ttyUSB0"
             ]
+        );
+    }
+
+    #[test]
+    fn check_ready_runs_meshtastic_info_without_real_cli() {
+        let commands = Rc::new(RefCell::new(Vec::new()));
+        let sender = MeshtasticSender::with_runner(
+            MeshtasticConfig {
+                host: Some("mesh.local:4403".to_string()),
+                port: None,
+            },
+            Box::new(RecordingCommandRunner {
+                commands: Rc::clone(&commands),
+                stdout: b"Connected to radio\n".to_vec(),
+            }),
+        );
+
+        sender.check_ready().unwrap();
+
+        assert_eq!(
+            *commands.borrow(),
+            vec![RecordedCommand {
+                program: "meshtastic".to_string(),
+                args: vec!["--host", "mesh.local:4403", "--info"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+            }]
+        );
+    }
+
+    #[test]
+    fn send_alert_runs_meshtastic_send_without_real_cli() {
+        let commands = Rc::new(RefCell::new(Vec::new()));
+        let mut sender = MeshtasticSender::with_runner(
+            MeshtasticConfig {
+                host: None,
+                port: Some("/dev/ttyUSB0".to_string()),
+            },
+            Box::new(RecordingCommandRunner {
+                commands: Rc::clone(&commands),
+                stdout: Vec::new(),
+            }),
+        );
+        let alert = Alert::new(
+            "Tornado Warning".to_string(),
+            crate::alert::AlertSignificance::Warning,
+            "National Weather Service".to_string(),
+            "KXYZ".to_string(),
+            false,
+            vec!["006085".to_string()],
+            vec!["Central Santa Clara".to_string()],
+            "short alert".to_string(),
+        );
+
+        sender.send_alert(&alert, 3).unwrap();
+
+        assert_eq!(
+            *commands.borrow(),
+            vec![RecordedCommand {
+                program: "meshtastic".to_string(),
+                args: vec![
+                    "--no-nodes",
+                    "--no-time",
+                    "--ch-index",
+                    "3",
+                    "--sendtext",
+                    "short alert",
+                    "--ack",
+                    "--port",
+                    "/dev/ttyUSB0",
+                ]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            }]
         );
     }
 }

--- a/src/meshtastic_sender.rs
+++ b/src/meshtastic_sender.rs
@@ -140,6 +140,10 @@ impl MeshtasticSender {
 }
 
 impl Sender for MeshtasticSender {
+    fn name(&self) -> &'static str {
+        "meshtastic"
+    }
+
     fn check_ready(&self) -> Result<()> {
         let output = self
             .runner

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,0 +1,33 @@
+use crate::alert::Alert;
+use anyhow::Result;
+
+pub trait Sender {
+    fn check_ready(&self) -> Result<()>;
+    fn send_alert(&mut self, alert: &Alert, channel: u32) -> Result<()>;
+}
+
+pub struct FanOut {
+    senders: Vec<Box<dyn Sender>>,
+}
+
+impl FanOut {
+    pub fn new(senders: Vec<Box<dyn Sender>>) -> Self {
+        Self { senders }
+    }
+
+    pub fn check_ready(&self) -> Result<()> {
+        for sender in &self.senders {
+            sender.check_ready()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn send_alert(&mut self, alert: &Alert, channel: u32) -> Result<()> {
+        for sender in &mut self.senders {
+            sender.send_alert(alert, channel)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -7,27 +7,182 @@ pub trait Sender {
 }
 
 pub struct FanOut {
-    senders: Vec<Box<dyn Sender>>,
+    required_senders: Vec<Box<dyn Sender>>,
+    best_effort_senders: Vec<Box<dyn Sender>>,
 }
 
 impl FanOut {
-    pub fn new(senders: Vec<Box<dyn Sender>>) -> Self {
-        Self { senders }
+    pub fn new(required_senders: Vec<Box<dyn Sender>>) -> Self {
+        Self {
+            required_senders,
+            best_effort_senders: Vec::new(),
+        }
+    }
+
+    pub fn with_best_effort(
+        required_senders: Vec<Box<dyn Sender>>,
+        best_effort_senders: Vec<Box<dyn Sender>>,
+    ) -> Self {
+        Self {
+            required_senders,
+            best_effort_senders,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn required_sender_count(&self) -> usize {
+        self.required_senders.len()
+    }
+
+    #[cfg(test)]
+    pub fn best_effort_sender_count(&self) -> usize {
+        self.best_effort_senders.len()
     }
 
     pub fn check_ready(&self) -> Result<()> {
-        for sender in &self.senders {
+        for sender in &self.required_senders {
             sender.check_ready()?;
+        }
+
+        for sender in &self.best_effort_senders {
+            if let Err(e) = sender.check_ready() {
+                log::warn!("Best-effort sender readiness check failed: {}", e);
+            }
         }
 
         Ok(())
     }
 
     pub fn send_alert(&mut self, alert: &Alert, channel: u32) -> Result<()> {
-        for sender in &mut self.senders {
+        for sender in &mut self.required_senders {
             sender.send_alert(alert, channel)?;
         }
 
+        for sender in &mut self.best_effort_senders {
+            if let Err(e) = sender.send_alert(alert, channel) {
+                log::warn!("Best-effort sender failed: {}", e);
+            }
+        }
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alert::{Alert, AlertSignificance};
+    use anyhow::anyhow;
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    struct RecordingSender {
+        label: &'static str,
+        calls: Rc<RefCell<Vec<&'static str>>>,
+        ready_error: Option<&'static str>,
+        send_error: Option<&'static str>,
+        send_count: Rc<Cell<u32>>,
+    }
+
+    impl RecordingSender {
+        fn new(label: &'static str, calls: Rc<RefCell<Vec<&'static str>>>) -> Self {
+            Self {
+                label,
+                calls,
+                ready_error: None,
+                send_error: None,
+                send_count: Rc::new(Cell::new(0)),
+            }
+        }
+
+        fn with_send_error(mut self, error: &'static str) -> Self {
+            self.send_error = Some(error);
+            self
+        }
+
+        fn with_ready_error(mut self, error: &'static str) -> Self {
+            self.ready_error = Some(error);
+            self
+        }
+    }
+
+    impl Sender for RecordingSender {
+        fn check_ready(&self) -> Result<()> {
+            if let Some(error) = self.ready_error {
+                Err(anyhow!(error))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn send_alert(&mut self, _alert: &Alert, _channel: u32) -> Result<()> {
+            self.calls.borrow_mut().push(self.label);
+            self.send_count.set(self.send_count.get() + 1);
+
+            if let Some(error) = self.send_error {
+                Err(anyhow!(error))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn test_alert() -> Alert {
+        Alert::new(
+            "Tornado Warning".to_string(),
+            AlertSignificance::Warning,
+            "National Weather Service".to_string(),
+            "KXYZ".to_string(),
+            false,
+            Vec::new(),
+            Vec::new(),
+            "test alert".to_string(),
+        )
+    }
+
+    #[test]
+    fn required_sender_failure_returns_error() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let mut fanout = FanOut::new(vec![Box::new(
+            RecordingSender::new("required", Rc::clone(&calls)).with_send_error("required failed"),
+        )]);
+
+        assert!(fanout.send_alert(&test_alert(), 0).is_err());
+        assert_eq!(*calls.borrow(), vec!["required"]);
+    }
+
+    #[test]
+    fn best_effort_sender_failure_does_not_block_required_sender() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let mut fanout = FanOut::with_best_effort(
+            vec![Box::new(RecordingSender::new(
+                "required",
+                Rc::clone(&calls),
+            ))],
+            vec![Box::new(
+                RecordingSender::new("best-effort", Rc::clone(&calls))
+                    .with_send_error("optional failed"),
+            )],
+        );
+
+        assert!(fanout.send_alert(&test_alert(), 0).is_ok());
+        assert_eq!(*calls.borrow(), vec!["required", "best-effort"]);
+    }
+
+    #[test]
+    fn best_effort_readiness_failure_does_not_fail_startup() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let fanout = FanOut::with_best_effort(
+            vec![Box::new(RecordingSender::new(
+                "required",
+                Rc::clone(&calls),
+            ))],
+            vec![Box::new(
+                RecordingSender::new("best-effort", Rc::clone(&calls))
+                    .with_ready_error("optional unavailable"),
+            )],
+        );
+
+        assert!(fanout.check_ready().is_ok());
     }
 }

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,7 +1,9 @@
 use crate::alert::Alert;
+use crate::spool::{SpoolRecord, Spooler};
 use anyhow::Result;
 
 pub trait Sender {
+    fn name(&self) -> &'static str;
     fn check_ready(&self) -> Result<()>;
     fn send_alert(&mut self, alert: &Alert, channel: u32) -> Result<()>;
 }
@@ -9,6 +11,7 @@ pub trait Sender {
 pub struct FanOut {
     required_senders: Vec<Box<dyn Sender>>,
     best_effort_senders: Vec<Box<dyn Sender>>,
+    spooler: Option<Box<dyn Spooler>>,
 }
 
 impl FanOut {
@@ -16,6 +19,7 @@ impl FanOut {
         Self {
             required_senders,
             best_effort_senders: Vec::new(),
+            spooler: None,
         }
     }
 
@@ -26,7 +30,13 @@ impl FanOut {
         Self {
             required_senders,
             best_effort_senders,
+            spooler: None,
         }
+    }
+
+    pub fn with_spooler(mut self, spooler: Box<dyn Spooler>) -> Self {
+        self.spooler = Some(spooler);
+        self
     }
 
     #[cfg(test)]
@@ -37,6 +47,11 @@ impl FanOut {
     #[cfg(test)]
     pub fn best_effort_sender_count(&self) -> usize {
         self.best_effort_senders.len()
+    }
+
+    #[cfg(test)]
+    pub fn has_spooler(&self) -> bool {
+        self.spooler.is_some()
     }
 
     pub fn check_ready(&self) -> Result<()> {
@@ -61,6 +76,16 @@ impl FanOut {
         for sender in &mut self.best_effort_senders {
             if let Err(e) = sender.send_alert(alert, channel) {
                 log::warn!("Best-effort sender failed: {}", e);
+                if let Some(spooler) = &mut self.spooler {
+                    let record =
+                        SpoolRecord::from_failure(sender.name(), alert, channel, &e.to_string());
+                    if let Err(spool_error) = spooler.spool(&record) {
+                        log::warn!(
+                            "Failed to spool best-effort sender failure: {}",
+                            spool_error
+                        );
+                    }
+                }
             }
         }
 
@@ -107,6 +132,10 @@ mod tests {
     }
 
     impl Sender for RecordingSender {
+        fn name(&self) -> &'static str {
+            self.label
+        }
+
         fn check_ready(&self) -> Result<()> {
             if let Some(error) = self.ready_error {
                 Err(anyhow!(error))
@@ -120,6 +149,23 @@ mod tests {
             self.send_count.set(self.send_count.get() + 1);
 
             if let Some(error) = self.send_error {
+                Err(anyhow!(error))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    struct RecordingSpooler {
+        records: Rc<RefCell<Vec<SpoolRecord>>>,
+        error: Option<&'static str>,
+    }
+
+    impl Spooler for RecordingSpooler {
+        fn spool(&mut self, record: &SpoolRecord) -> Result<()> {
+            self.records.borrow_mut().push(record.clone());
+
+            if let Some(error) = self.error {
                 Err(anyhow!(error))
             } else {
                 Ok(())
@@ -184,5 +230,73 @@ mod tests {
         );
 
         assert!(fanout.check_ready().is_ok());
+    }
+
+    #[test]
+    fn best_effort_sender_failure_is_spooled_when_configured() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let spooled = Rc::new(RefCell::new(Vec::new()));
+        let mut fanout = FanOut::with_best_effort(
+            vec![Box::new(RecordingSender::new(
+                "required",
+                Rc::clone(&calls),
+            ))],
+            vec![Box::new(
+                RecordingSender::new("discord", Rc::clone(&calls))
+                    .with_send_error("optional failed"),
+            )],
+        )
+        .with_spooler(Box::new(RecordingSpooler {
+            records: Rc::clone(&spooled),
+            error: None,
+        }));
+
+        assert!(fanout.send_alert(&test_alert(), 4).is_ok());
+
+        let records = spooled.borrow();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].sender, "discord");
+        assert_eq!(records[0].channel, 4);
+        assert_eq!(records[0].error, "optional failed");
+        assert_eq!(records[0].message_text, "test alert");
+    }
+
+    #[test]
+    fn spool_write_failure_does_not_block_fanout_completion() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let spooled = Rc::new(RefCell::new(Vec::new()));
+        let mut fanout = FanOut::with_best_effort(
+            vec![Box::new(RecordingSender::new(
+                "required",
+                Rc::clone(&calls),
+            ))],
+            vec![Box::new(
+                RecordingSender::new("discord", Rc::clone(&calls))
+                    .with_send_error("optional failed"),
+            )],
+        )
+        .with_spooler(Box::new(RecordingSpooler {
+            records: Rc::clone(&spooled),
+            error: Some("disk unavailable"),
+        }));
+
+        assert!(fanout.send_alert(&test_alert(), 0).is_ok());
+        assert_eq!(spooled.borrow().len(), 1);
+    }
+
+    #[test]
+    fn required_sender_failure_is_not_spooled() {
+        let calls = Rc::new(RefCell::new(Vec::new()));
+        let spooled = Rc::new(RefCell::new(Vec::new()));
+        let mut fanout = FanOut::new(vec![Box::new(
+            RecordingSender::new("required", Rc::clone(&calls)).with_send_error("required failed"),
+        )])
+        .with_spooler(Box::new(RecordingSpooler {
+            records: Rc::clone(&spooled),
+            error: None,
+        }));
+
+        assert!(fanout.send_alert(&test_alert(), 0).is_err());
+        assert!(spooled.borrow().is_empty());
     }
 }

--- a/src/spool.rs
+++ b/src/spool.rs
@@ -1,0 +1,195 @@
+use crate::alert::{Alert, AlertSignificance};
+use anyhow::Result;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub trait Spooler {
+    fn spool(&mut self, record: &SpoolRecord) -> Result<()>;
+}
+
+pub struct FileSpooler {
+    path: PathBuf,
+}
+
+impl FileSpooler {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Spooler for FileSpooler {
+    fn spool(&mut self, record: &SpoolRecord) -> Result<()> {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        writeln!(file, "{}", record.to_json_line())?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpoolRecord {
+    pub timestamp_unix_secs: u64,
+    pub sender: String,
+    pub channel: u32,
+    pub error: String,
+    pub event: String,
+    pub significance: AlertSignificance,
+    pub originator: String,
+    pub callsign: String,
+    pub is_national: bool,
+    pub is_test: bool,
+    pub location_codes: Vec<String>,
+    pub location_names: Vec<String>,
+    pub message_text: String,
+}
+
+impl SpoolRecord {
+    pub fn from_failure(sender: &str, alert: &Alert, channel: u32, error: &str) -> Self {
+        Self::from_failure_at(
+            sender,
+            alert,
+            channel,
+            error,
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        )
+    }
+
+    pub fn from_failure_at(
+        sender: &str,
+        alert: &Alert,
+        channel: u32,
+        error: &str,
+        timestamp_unix_secs: u64,
+    ) -> Self {
+        Self {
+            timestamp_unix_secs,
+            sender: sender.to_string(),
+            channel,
+            error: error.to_string(),
+            event: alert.event.clone(),
+            significance: alert.significance,
+            originator: alert.originator.clone(),
+            callsign: alert.callsign.clone(),
+            is_national: alert.is_national,
+            is_test: alert.is_test,
+            location_codes: alert.location_codes.clone(),
+            location_names: alert.location_names.clone(),
+            message_text: alert.message_text.clone(),
+        }
+    }
+
+    pub fn to_json_line(&self) -> String {
+        format!(
+            "{{\"timestamp_unix_secs\":{},\"sender\":\"{}\",\"channel\":{},\"error\":\"{}\",\"event\":\"{}\",\"significance\":\"{:?}\",\"originator\":\"{}\",\"callsign\":\"{}\",\"is_national\":{},\"is_test\":{},\"location_codes\":{},\"location_names\":{},\"message_text\":\"{}\"}}",
+            self.timestamp_unix_secs,
+            json_escape(&self.sender),
+            self.channel,
+            json_escape(&self.error),
+            json_escape(&self.event),
+            self.significance,
+            json_escape(&self.originator),
+            json_escape(&self.callsign),
+            self.is_national,
+            self.is_test,
+            json_string_array(&self.location_codes),
+            json_string_array(&self.location_names),
+            json_escape(&self.message_text),
+        )
+    }
+}
+
+fn json_string_array(values: &[String]) -> String {
+    let values = values
+        .iter()
+        .map(|value| format!("\"{}\"", json_escape(value)))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!("[{}]", values)
+}
+
+fn json_escape(value: &str) -> String {
+    let mut escaped = String::new();
+
+    for ch in value.chars() {
+        match ch {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            c if c.is_control() => escaped.push_str(&format!("\\u{:04x}", c as u32)),
+            c => escaped.push(c),
+        }
+    }
+
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alert::AlertSignificance;
+    use std::fs;
+
+    fn test_alert(message_text: String) -> Alert {
+        Alert::new(
+            "Tornado Warning".to_string(),
+            AlertSignificance::Warning,
+            "National Weather Service".to_string(),
+            "KXYZ".to_string(),
+            false,
+            vec!["006085".to_string()],
+            vec!["Central Santa Clara".to_string()],
+            message_text,
+        )
+    }
+
+    #[test]
+    fn spool_record_serializes_to_one_escaped_json_line() {
+        let alert = test_alert("line 1\n\"quoted\" \\ path".to_string());
+        let record = SpoolRecord::from_failure_at(
+            "discord",
+            &alert,
+            2,
+            "failed \"badly\"\nwithout url",
+            123,
+        );
+
+        assert_eq!(
+            record.to_json_line(),
+            "{\"timestamp_unix_secs\":123,\"sender\":\"discord\",\"channel\":2,\"error\":\"failed \\\"badly\\\"\\nwithout url\",\"event\":\"Tornado Warning\",\"significance\":\"Warning\",\"originator\":\"National Weather Service\",\"callsign\":\"KXYZ\",\"is_national\":false,\"is_test\":false,\"location_codes\":[\"006085\"],\"location_names\":[\"Central Santa Clara\"],\"message_text\":\"line 1\\n\\\"quoted\\\" \\\\ path\"}"
+        );
+        assert!(!record.to_json_line().contains('\n'));
+    }
+
+    #[test]
+    fn file_spooler_appends_records() {
+        let path = std::env::temp_dir().join(format!(
+            "project-sentinel-spool-test-{}-{}.jsonl",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let alert = test_alert("alert text".to_string());
+        let record = SpoolRecord::from_failure_at("discord", &alert, 0, "failed", 456);
+        let mut spooler = FileSpooler::new(path.clone());
+
+        spooler.spool(&record).unwrap();
+        spooler.spool(&record).unwrap();
+
+        let contents = fs::read_to_string(&path).unwrap();
+        let expected = format!("{}\n{}\n", record.to_json_line(), record.to_json_line());
+        assert_eq!(contents, expected);
+
+        let _ = fs::remove_file(path);
+    }
+}


### PR DESCRIPTION
## Summary

This PR transitions project documentation from the inherited Meshtastic-SAME-EAS-Alerter identity to Sentinel.

No runtime behavior changes are included.

## Changes

- Replaced the inherited README with Sentinel-focused documentation.
- Added ROADMAP documentation describing completed and planned milestones.
- Added ARCHITECTURE documentation describing Sentinel's current design and future evolution.
- Preserved acknowledgment of the original upstream project.

## Validation

- Documentation-only change.
- No source code modifications.
- No dependency changes.

## Compatibility

This PR does not alter application behavior.

## Out of Scope

- New integrations
- Retry workers
- Reticulum/LXMF
- MeshCore
- Dashboard functionality
- Skywarn ingestion
- ATAK interoperability

These capabilities remain roadmap items.